### PR TITLE
ci: Add coverage reporting and threshold enforcement

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,8 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -30,5 +32,28 @@ jobs:
       - name: Upload coverage artifact
         uses: actions/upload-artifact@v4
         with:
-          name: coverage
+          name: code-coverage
           path: coverage.out
+
+      - name: Check coverage threshold
+        uses: vladopajic/go-test-coverage@v2
+        with:
+          config: ./.testcoverage.yml
+          profile: coverage.out
+          git-token: ${{ github.ref_name == 'master' && secrets.GITHUB_TOKEN || '' }}
+          git-branch: badges
+
+  coverage-report:
+    name: Coverage report
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    needs: test
+    permissions:
+      contents: read
+      actions: read
+      pull-requests: write
+    steps:
+      - uses: fgrosse/go-coverage-report@v1.1.1
+        with:
+          coverage-artifact-name: code-coverage
+          coverage-file-name: coverage.out

--- a/.testcoverage.yml
+++ b/.testcoverage.yml
@@ -1,0 +1,6 @@
+profile: coverage.out
+
+threshold:
+  # Minimum overall project coverage percentage required.
+  # Raise this as test coverage improves (see #35).
+  total: 60

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # cisshgo
 
+![coverage](https://raw.githubusercontent.com/tbotnz/cisshgo/badges/.badges/master/coverage.svg)
+
 Simple, small, fast, concurrent SSH server to emulate network equipment (i.e. Cisco IOS) for testing purposes.
 
 ## Quick Start


### PR DESCRIPTION
## Summary

Add coverage reporting infrastructure with threshold enforcement and badge generation.

### Changes
- `.testcoverage.yml` — 60% total coverage threshold (configurable)
- `test.yml` — extended with:
  - [`vladopajic/go-test-coverage@v2`](https://github.com/vladopajic/go-test-coverage) for threshold enforcement and badge generation on master
  - [`fgrosse/go-coverage-report@v1.1.1`](https://github.com/fgrosse/go-coverage-report) for PR coverage diff comments
- `README.md` — coverage badge from `badges` orphan branch
- Created `badges` orphan branch for badge SVG hosting

### Notes
- The 60% threshold will cause CI to fail until #35 (unit tests) is completed — this is intentional
- Badge will populate once the first master build runs with this workflow

Closes #34
Part of #32