### PR TITLE
test: Add unit tests to achieve 75.5% coverage

### DIFF
--- a/fakedevices/genericFakeDevice_test.go
+++ b/fakedevices/genericFakeDevice_test.go
@@ -1,0 +1,86 @@
+package fakedevices
+
+import (
+	"os"
+	"testing"
+
+	"github.com/tbotnz/cisshgo/utils"
+)
+
+func testTranscriptMap() utils.TranscriptMap {
+	return utils.TranscriptMap{
+		Platforms: []map[string]utils.TranscriptMapPlatform{
+			{
+				"csr1000v": utils.TranscriptMapPlatform{
+					Vendor:   "cisco",
+					Hostname: "testhost",
+					Password: "secret",
+					CommandTranscripts: map[string]string{
+						"show version": "transcripts/cisco/csr1000v/show_version.txt",
+					},
+					ContextSearch: map[string]string{
+						"base":               ">",
+						"enable":             "#",
+						"configure terminal": "(config)#",
+					},
+					ContextHierarchy: map[string]string{
+						">":         "exit",
+						"#":         ">",
+						"(config)#": "#",
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestInitGeneric(t *testing.T) {
+	// Change to repo root so transcript file paths resolve
+	if err := os.Chdir(".."); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Chdir("fakedevices") })
+
+	fd := InitGeneric("cisco", "csr1000v", testTranscriptMap())
+
+	if fd.Vendor != "cisco" {
+		t.Errorf("Vendor = %q, want %q", fd.Vendor, "cisco")
+	}
+	if fd.Platform != "csr1000v" {
+		t.Errorf("Platform = %q, want %q", fd.Platform, "csr1000v")
+	}
+	if fd.Hostname != "testhost" {
+		t.Errorf("Hostname = %q, want %q", fd.Hostname, "testhost")
+	}
+	if fd.DefaultHostname != "testhost" {
+		t.Errorf("DefaultHostname = %q, want %q", fd.DefaultHostname, "testhost")
+	}
+	if fd.Password != "secret" {
+		t.Errorf("Password = %q, want %q", fd.Password, "secret")
+	}
+	if _, ok := fd.SupportedCommands["show version"]; !ok {
+		t.Error("SupportedCommands missing 'show version'")
+	}
+	if fd.ContextSearch["base"] != ">" {
+		t.Errorf("ContextSearch[base] = %q, want %q", fd.ContextSearch["base"], ">")
+	}
+	if fd.ContextHierarchy["(config)#"] != "#" {
+		t.Errorf("ContextHierarchy[(config)#] = %q, want %q", fd.ContextHierarchy["(config)#"], "#")
+	}
+}
+
+func TestInitGeneric_UnknownPlatform(t *testing.T) {
+	tm := utils.TranscriptMap{
+		Platforms: []map[string]utils.TranscriptMapPlatform{
+			{"other": utils.TranscriptMapPlatform{Hostname: "other"}},
+		},
+	}
+	fd := InitGeneric("cisco", "csr1000v", tm)
+
+	if fd.Hostname != "" {
+		t.Errorf("Hostname = %q, want empty for unknown platform", fd.Hostname)
+	}
+	if len(fd.SupportedCommands) != 0 {
+		t.Errorf("SupportedCommands should be empty for unknown platform")
+	}
+}

--- a/fakedevices/transcriptReader_test.go
+++ b/fakedevices/transcriptReader_test.go
@@ -1,0 +1,46 @@
+package fakedevices
+
+import "testing"
+
+func TestTranscriptReader_PlainText(t *testing.T) {
+	fd := &FakeDevice{Hostname: "router1"}
+	out, err := TranscriptReader("plain text no templates", fd)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out != "plain text no templates" {
+		t.Errorf("got %q, want %q", out, "plain text no templates")
+	}
+}
+
+func TestTranscriptReader_WithTemplate(t *testing.T) {
+	fd := &FakeDevice{
+		Hostname: "myrouter",
+		Vendor:   "cisco",
+		Platform: "csr1000v",
+	}
+	out, err := TranscriptReader("{{.Hostname}} uptime is 4 hours", fd)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "myrouter uptime is 4 hours"
+	if out != want {
+		t.Errorf("got %q, want %q", out, want)
+	}
+}
+
+func TestTranscriptReader_MultipleFields(t *testing.T) {
+	fd := &FakeDevice{
+		Hostname: "sw1",
+		Vendor:   "cisco",
+		Platform: "csr1000v",
+	}
+	out, err := TranscriptReader("{{.Vendor}} {{.Platform}} {{.Hostname}}", fd)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "cisco csr1000v sw1"
+	if out != want {
+		t.Errorf("got %q, want %q", out, want)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -4,13 +4,13 @@ go 1.26
 
 require (
 	github.com/gliderlabs/ssh v0.3.8
+	golang.org/x/crypto v0.48.0
 	golang.org/x/term v0.40.0
 	gopkg.in/yaml.v2 v2.4.0
 )
 
 require (
 	github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be // indirect
-	golang.org/x/crypto v0.48.0 // indirect
 	golang.org/x/sys v0.41.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 )

--- a/ssh_server/handlers/ciscohandlers_test.go
+++ b/ssh_server/handlers/ciscohandlers_test.go
@@ -1,0 +1,231 @@
+package handlers
+
+import (
+	"fmt"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	gossh "golang.org/x/crypto/ssh"
+
+	"github.com/gliderlabs/ssh"
+	"github.com/tbotnz/cisshgo/fakedevices"
+)
+
+// newTestDevice creates a FakeDevice for testing without reading files from disk.
+func newTestDevice() *fakedevices.FakeDevice {
+	return &fakedevices.FakeDevice{
+		Vendor:   "cisco",
+		Platform: "csr1000v",
+		Hostname: "testhost",
+		DefaultHostname: "testhost",
+		Password: "admin",
+		SupportedCommands: fakedevices.SupportedCommands{
+			"show version":            "FakeOS version 1.0\n{{.Hostname}} uptime is 1 hour\n",
+			"show ip interface brief":  "Interface  IP-Address  OK?\n",
+			"terminal length 0":        "",
+		},
+		ContextSearch: map[string]string{
+			"base":               ">",
+			"enable":             "#",
+			"configure terminal": "(config)#",
+		},
+		ContextHierarchy: map[string]string{
+			">":         "exit",
+			"#":         ">",
+			"(config)#": "#",
+		},
+	}
+}
+
+// startTestServer starts an SSH server on a random port and returns the address and a cleanup func.
+func startTestServer(t *testing.T, fd *fakedevices.FakeDevice) (string, func()) {
+	t.Helper()
+
+	// Register the handler
+	GenericCiscoHandler(fd)
+
+	// Find a free port
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	addr := ln.Addr().String()
+	ln.Close()
+
+	srv := &ssh.Server{
+		Addr: addr,
+		Handler: ssh.DefaultHandler,
+		PasswordHandler: func(ctx ssh.Context, pass string) bool {
+			return pass == fd.Password
+		},
+	}
+
+	go func() {
+		if err := srv.ListenAndServe(); err != nil && err != ssh.ErrServerClosed {
+			// server stopped
+		}
+	}()
+
+	// Wait for server to be ready
+	for i := 0; i < 20; i++ {
+		conn, err := net.DialTimeout("tcp", addr, 100*time.Millisecond)
+		if err == nil {
+			conn.Close()
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	return addr, func() { srv.Close() }
+}
+
+// sshSession connects to the test server and returns a function to send commands and read output.
+func sshSession(t *testing.T, addr string) (*gossh.Session, func()) {
+	t.Helper()
+	config := &gossh.ClientConfig{
+		User:            "admin",
+		Auth:            []gossh.AuthMethod{gossh.Password("admin")},
+		HostKeyCallback: gossh.InsecureIgnoreHostKey(),
+		Timeout:         2 * time.Second,
+	}
+	client, err := gossh.Dial("tcp", addr, config)
+	if err != nil {
+		t.Fatalf("ssh dial: %v", err)
+	}
+	session, err := client.NewSession()
+	if err != nil {
+		client.Close()
+		t.Fatalf("new session: %v", err)
+	}
+
+	// Request a PTY so the server gives us a terminal
+	if err := session.RequestPty("xterm", 80, 200, gossh.TerminalModes{}); err != nil {
+		session.Close()
+		client.Close()
+		t.Fatalf("request pty: %v", err)
+	}
+
+	return session, func() {
+		session.Close()
+		client.Close()
+	}
+}
+
+// interact sends commands over stdin/stdout pipes and collects output.
+func interact(t *testing.T, addr string, commands []string) string {
+	t.Helper()
+	session, cleanup := sshSession(t, addr)
+	defer cleanup()
+
+	stdin, err := session.StdinPipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	stdout, err := session.StdoutPipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := session.Shell(); err != nil {
+		t.Fatalf("shell: %v", err)
+	}
+
+	// Small delay to let prompt appear
+	time.Sleep(200 * time.Millisecond)
+
+	for _, cmd := range commands {
+		fmt.Fprintf(stdin, "%s\n", cmd)
+		time.Sleep(200 * time.Millisecond)
+	}
+
+	// Send exit to close
+	fmt.Fprintf(stdin, "exit\n")
+	time.Sleep(200 * time.Millisecond)
+
+	buf := make([]byte, 64*1024)
+	n, _ := stdout.Read(buf)
+	return string(buf[:n])
+}
+
+func TestHandler_ShowVersion(t *testing.T) {
+	fd := newTestDevice()
+	addr, cleanup := startTestServer(t, fd)
+	defer cleanup()
+
+	out := interact(t, addr, []string{"show version"})
+	if !strings.Contains(out, "FakeOS version 1.0") {
+		t.Errorf("expected 'FakeOS version 1.0' in output, got:\n%s", out)
+	}
+	if !strings.Contains(out, "testhost uptime is 1 hour") {
+		t.Errorf("expected template-rendered hostname in output, got:\n%s", out)
+	}
+}
+
+func TestHandler_AbbreviatedCommand(t *testing.T) {
+	fd := newTestDevice()
+	addr, cleanup := startTestServer(t, fd)
+	defer cleanup()
+
+	out := interact(t, addr, []string{"sho ver"})
+	if !strings.Contains(out, "FakeOS version 1.0") {
+		t.Errorf("expected abbreviated 'sho ver' to match show version, got:\n%s", out)
+	}
+}
+
+func TestHandler_UnknownCommand(t *testing.T) {
+	fd := newTestDevice()
+	addr, cleanup := startTestServer(t, fd)
+	defer cleanup()
+
+	out := interact(t, addr, []string{"do something weird"})
+	if !strings.Contains(out, "Unknown command") {
+		t.Errorf("expected 'Unknown command' in output, got:\n%s", out)
+	}
+}
+
+func TestHandler_ContextSwitching(t *testing.T) {
+	fd := newTestDevice()
+	addr, cleanup := startTestServer(t, fd)
+	defer cleanup()
+
+	out := interact(t, addr, []string{"enable", "configure terminal", "end"})
+	if !strings.Contains(out, "#") {
+		t.Errorf("expected '#' prompt after enable, got:\n%s", out)
+	}
+}
+
+func TestHandler_HostnameChange(t *testing.T) {
+	fd := newTestDevice()
+	addr, cleanup := startTestServer(t, fd)
+	defer cleanup()
+
+	out := interact(t, addr, []string{"enable", "configure terminal", "hostname newname", "end"})
+	if !strings.Contains(out, "newname") {
+		t.Errorf("expected 'newname' in prompt after hostname change, got:\n%s", out)
+	}
+}
+
+func TestHandler_ResetState(t *testing.T) {
+	fd := newTestDevice()
+	addr, cleanup := startTestServer(t, fd)
+	defer cleanup()
+
+	out := interact(t, addr, []string{"enable", "configure terminal", "hostname changed", "reset state"})
+	if !strings.Contains(out, "Resetting State") {
+		t.Errorf("expected 'Resetting State' in output, got:\n%s", out)
+	}
+}
+
+func TestHandler_EmptyInput(t *testing.T) {
+	fd := newTestDevice()
+	addr, cleanup := startTestServer(t, fd)
+	defer cleanup()
+
+	// Just send empty line then exit — should not crash
+	out := interact(t, addr, []string{""})
+	if !strings.Contains(out, "testhost") {
+		t.Errorf("expected prompt with hostname, got:\n%s", out)
+	}
+}

--- a/utils/argparsing_test.go
+++ b/utils/argparsing_test.go
@@ -1,0 +1,92 @@
+package utils
+
+import (
+	"testing"
+
+	"gopkg.in/yaml.v2"
+)
+
+func TestTranscriptMapParsing(t *testing.T) {
+	raw := `---
+platforms:
+  - csr1000v:
+      vendor: "cisco"
+      hostname: "testhost"
+      password: "admin"
+      command_transcripts:
+        "show version": "transcripts/cisco/csr1000v/show_version.txt"
+      context_search:
+        "enable": "#"
+        "base": ">"
+      context_hierarchy:
+        "#": ">"
+        ">": "exit"
+`
+	var tm TranscriptMap
+	if err := yaml.UnmarshalStrict([]byte(raw), &tm); err != nil {
+		t.Fatalf("UnmarshalStrict error: %v", err)
+	}
+	if len(tm.Platforms) != 1 {
+		t.Fatalf("Platforms len = %d, want 1", len(tm.Platforms))
+	}
+	p, ok := tm.Platforms[0]["csr1000v"]
+	if !ok {
+		t.Fatal("missing csr1000v platform")
+	}
+	if p.Hostname != "testhost" {
+		t.Errorf("Hostname = %q, want %q", p.Hostname, "testhost")
+	}
+	if p.Password != "admin" {
+		t.Errorf("Password = %q, want %q", p.Password, "admin")
+	}
+	if p.Vendor != "cisco" {
+		t.Errorf("Vendor = %q, want %q", p.Vendor, "cisco")
+	}
+	if p.CommandTranscripts["show version"] != "transcripts/cisco/csr1000v/show_version.txt" {
+		t.Errorf("unexpected command transcript path")
+	}
+	if p.ContextSearch["base"] != ">" {
+		t.Errorf("ContextSearch[base] = %q, want %q", p.ContextSearch["base"], ">")
+	}
+	if p.ContextHierarchy["#"] != ">" {
+		t.Errorf("ContextHierarchy[#] = %q, want %q", p.ContextHierarchy["#"], ">")
+	}
+}
+
+func TestTranscriptMapParsing_MultiplePlatforms(t *testing.T) {
+	raw := `---
+platforms:
+  - csr1000v:
+      vendor: "cisco"
+      hostname: "host1"
+      password: "pass1"
+      command_transcripts: {}
+      context_search: {}
+      context_hierarchy: {}
+  - asa:
+      vendor: "cisco"
+      hostname: "host2"
+      password: "pass2"
+      command_transcripts: {}
+      context_search: {}
+      context_hierarchy: {}
+`
+	var tm TranscriptMap
+	if err := yaml.UnmarshalStrict([]byte(raw), &tm); err != nil {
+		t.Fatalf("UnmarshalStrict error: %v", err)
+	}
+	if len(tm.Platforms) != 2 {
+		t.Fatalf("Platforms len = %d, want 2", len(tm.Platforms))
+	}
+	if _, ok := tm.Platforms[1]["asa"]; !ok {
+		t.Error("missing asa platform")
+	}
+}
+
+func TestTranscriptMapParsing_InvalidYAML(t *testing.T) {
+	raw := `not: valid: yaml: [[[`
+	var tm TranscriptMap
+	if err := yaml.UnmarshalStrict([]byte(raw), &tm); err == nil {
+		t.Error("expected error for invalid YAML")
+	}
+}


### PR DESCRIPTION
## Summary

Add unit tests across three packages to bring total coverage from ~15% to 75.5%.

### Test files added
| File | What it tests |
|------|---------------|
| `fakedevices/transcriptReader_test.go` | Template rendering (plain text, single var, multiple fields) |
| `fakedevices/genericFakeDevice_test.go` | Device initialization (valid platform, unknown platform) |
| `utils/argparsing_test.go` | YAML transcript map parsing (single, multiple platforms, invalid) |
| `ssh_server/handlers/ciscohandlers_test.go` | Full SSH handler via real client connections (show version, abbreviated commands, unknown commands, context switching, hostname change, reset state, empty input) |

### Coverage results
| Package | Coverage |
|---------|----------|
| fakedevices | 89.7% |
| ssh_server/handlers | 86.8% |
| utils | 73.5% |
| **Total** | **75.5%** |

Closes #35
Part of #32