### PR TITLE
docs: Add standard Go ecosystem badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # cisshgo
 
-![coverage](https://raw.githubusercontent.com/tbotnz/cisshgo/badges/.badges/master/coverage.svg)
+[![CI](https://github.com/tbotnz/cisshgo/actions/workflows/test.yml/badge.svg)](https://github.com/tbotnz/cisshgo/actions/workflows/test.yml)
+[![coverage](https://raw.githubusercontent.com/tbotnz/cisshgo/badges/.badges/master/coverage.svg)](https://github.com/tbotnz/cisshgo/actions/workflows/test.yml)
+[![Go Report Card](https://goreportcard.com/badge/github.com/tbotnz/cisshgo)](https://goreportcard.com/report/github.com/tbotnz/cisshgo)
+[![Go Reference](https://pkg.go.dev/badge/github.com/tbotnz/cisshgo.svg)](https://pkg.go.dev/github.com/tbotnz/cisshgo)
+[![Release](https://img.shields.io/github/v/release/tbotnz/cisshgo)](https://github.com/tbotnz/cisshgo/releases)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 Simple, small, fast, concurrent SSH server to emulate network equipment (i.e. Cisco IOS) for testing purposes.
 


### PR DESCRIPTION
Add standard Go ecosystem badges to the README:

- **CI** — test workflow pass/fail status
- **Coverage** — existing badge, now linked to workflow
- **Go Report Card** — code quality grade (lint, vet, fmt)
- **Go Reference** — pkg.go.dev API documentation
- **Release** — latest release version
- **License** — MIT license visibility

Closes #40