### PR TITLE
feat: Add SSH exec mode support

### DIFF
--- a/ssh_server/handlers/ciscohandlers.go
+++ b/ssh_server/handlers/ciscohandlers.go
@@ -3,6 +3,7 @@
 package handlers
 
 import (
+	"io"
 	"log"
 	"strings"
 
@@ -19,7 +20,23 @@ func GenericCiscoHandler(myFakeDevice *fakedevices.FakeDevice) {
 	// Prepare the "ssh.DefaultHandler", this houses our device specific functionality
 	ssh.Handle(func(s ssh.Session) {
 
-		// Setup our initial "context" or prompt
+		// Exec mode: client sent a command directly (e.g., ssh host "show version")
+		if cmd := s.RawCommand(); cmd != "" {
+			log.Printf("exec: %s", cmd)
+			match, matchedCommand, multipleMatches, _ := utils.CmdMatch(cmd, myFakeDevice.SupportedCommands)
+			if match && !multipleMatches {
+				output, err := fakedevices.TranscriptReader(
+					myFakeDevice.SupportedCommands[matchedCommand], myFakeDevice,
+				)
+				if err == nil {
+					io.WriteString(s, output)
+				}
+			}
+			s.Exit(0)
+			return
+		}
+
+		// Interactive shell mode
 		ContextState := myFakeDevice.ContextSearch["base"]
 
 		// Setup a terminal with the hostname + initial context state as a prompt

--- a/ssh_server/handlers/ciscohandlers_test.go
+++ b/ssh_server/handlers/ciscohandlers_test.go
@@ -218,6 +218,102 @@ func TestHandler_ResetState(t *testing.T) {
 	}
 }
 
+func TestExec_ShowVersion(t *testing.T) {
+	fd := newTestDevice()
+	addr, cleanup := startTestServer(t, fd)
+	defer cleanup()
+
+	config := &gossh.ClientConfig{
+		User:            "admin",
+		Auth:            []gossh.AuthMethod{gossh.Password("admin")},
+		HostKeyCallback: gossh.InsecureIgnoreHostKey(),
+		Timeout:         2 * time.Second,
+	}
+	client, err := gossh.Dial("tcp", addr, config)
+	if err != nil {
+		t.Fatalf("ssh dial: %v", err)
+	}
+	defer client.Close()
+
+	session, err := client.NewSession()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer session.Close()
+
+	out, err := session.Output("show version")
+	if err != nil {
+		t.Fatalf("exec: %v", err)
+	}
+	if !strings.Contains(string(out), "FakeOS version 1.0") {
+		t.Errorf("expected 'FakeOS version 1.0' in exec output, got:\n%s", out)
+	}
+}
+
+func TestExec_AbbreviatedCommand(t *testing.T) {
+	fd := newTestDevice()
+	addr, cleanup := startTestServer(t, fd)
+	defer cleanup()
+
+	config := &gossh.ClientConfig{
+		User:            "admin",
+		Auth:            []gossh.AuthMethod{gossh.Password("admin")},
+		HostKeyCallback: gossh.InsecureIgnoreHostKey(),
+		Timeout:         2 * time.Second,
+	}
+	client, err := gossh.Dial("tcp", addr, config)
+	if err != nil {
+		t.Fatalf("ssh dial: %v", err)
+	}
+	defer client.Close()
+
+	session, err := client.NewSession()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer session.Close()
+
+	out, err := session.Output("sho ver")
+	if err != nil {
+		t.Fatalf("exec: %v", err)
+	}
+	if !strings.Contains(string(out), "FakeOS version 1.0") {
+		t.Errorf("expected abbreviated match in exec output, got:\n%s", out)
+	}
+}
+
+func TestExec_UnknownCommand(t *testing.T) {
+	fd := newTestDevice()
+	addr, cleanup := startTestServer(t, fd)
+	defer cleanup()
+
+	config := &gossh.ClientConfig{
+		User:            "admin",
+		Auth:            []gossh.AuthMethod{gossh.Password("admin")},
+		HostKeyCallback: gossh.InsecureIgnoreHostKey(),
+		Timeout:         2 * time.Second,
+	}
+	client, err := gossh.Dial("tcp", addr, config)
+	if err != nil {
+		t.Fatalf("ssh dial: %v", err)
+	}
+	defer client.Close()
+
+	session, err := client.NewSession()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer session.Close()
+
+	out, err := session.Output("bogus command")
+	if err != nil {
+		t.Fatalf("exec: %v", err)
+	}
+	if len(out) != 0 {
+		t.Errorf("expected empty output for unknown command, got:\n%s", out)
+	}
+}
+
 func TestHandler_EmptyInput(t *testing.T) {
 	fd := newTestDevice()
 	addr, cleanup := startTestServer(t, fd)


### PR DESCRIPTION
## Summary

Add support for SSH exec mode, fixing a 5-year-old issue where programmatic SSH clients (asyncssh, Netmiko, Paramiko, SuzieQ) would hang when sending commands via exec channel.

### The problem
cisshgo only handled interactive shell sessions. When a client sent `ssh host "show version"`, the exec request was never processed and the connection hung.

### The fix
Check `s.RawCommand()` at the top of the handler. If non-empty, the client is in exec mode — process the command through CmdMatch, render the output via TranscriptReader, write it to the session, and exit cleanly. Otherwise fall through to the existing interactive shell logic.

### Tests added
- `TestExec_ShowVersion` — exec with full command
- `TestExec_AbbreviatedCommand` — exec with abbreviated command (`sho ver`)
- `TestExec_UnknownCommand` — exec with unrecognized command (empty output, clean exit)

Closes #23