### PR TITLE
feat: Implement inventory system for multi-device topology management

### DIFF
--- a/cissh.go
+++ b/cissh.go
@@ -3,7 +3,7 @@
 //
 // Usage:
 //
-//	cisshgo [-listeners N] [-startingPort N] [-transcriptMap path]
+//	cisshgo [--inventory path] [--platform name] [--listeners N] [--starting-port N] [--transcript-map path]
 package main
 
 import (
@@ -21,27 +21,54 @@ import (
 	"github.com/tbotnz/cisshgo/utils"
 )
 
+type listenerSpec struct {
+	fd   *fakedevices.FakeDevice
+	port int
+}
+
 func run(ctx context.Context, cli utils.CLI) error {
 	myTranscriptMap, err := utils.LoadTranscriptMap(cli.TranscriptMap)
 	if err != nil {
 		return err
 	}
 
-	myFakeDevice, err := fakedevices.InitGeneric("cisco", "csr1000v", myTranscriptMap)
-	if err != nil {
-		return err
+	var specs []listenerSpec
+
+	if cli.Inventory != "" {
+		inv, err := utils.LoadInventory(cli.Inventory)
+		if err != nil {
+			return err
+		}
+		port := cli.StartingPort
+		for _, entry := range inv.Devices {
+			fd, err := fakedevices.InitGeneric(entry.Platform, myTranscriptMap)
+			if err != nil {
+				return err
+			}
+			for i := 0; i < entry.Count; i++ {
+				specs = append(specs, listenerSpec{fd, port})
+				port++
+			}
+		}
+	} else {
+		fd, err := fakedevices.InitGeneric(cli.Platform, myTranscriptMap)
+		if err != nil {
+			return err
+		}
+		for port := cli.StartingPort; port < cli.StartingPort+cli.Listeners; port++ {
+			specs = append(specs, listenerSpec{fd, port})
+		}
 	}
 
 	var wg sync.WaitGroup
-	numListeners := cli.StartingPort + cli.Listeners
-	for portNumber := cli.StartingPort; portNumber < numListeners; portNumber++ { // coverage-ignore
-		wg.Add(1)           // coverage-ignore
-		go func(port int) { // coverage-ignore
-			defer wg.Done()                                                                                             // coverage-ignore
-			if err := sshlisteners.GenericListener(ctx, myFakeDevice, port, handlers.GenericCiscoHandler); err != nil { // coverage-ignore
+	for _, spec := range specs { // coverage-ignore
+		wg.Add(1)                                       // coverage-ignore
+		go func(fd *fakedevices.FakeDevice, port int) { // coverage-ignore
+			defer wg.Done()                                                                                   // coverage-ignore
+			if err := sshlisteners.GenericListener(ctx, fd, port, handlers.GenericCiscoHandler); err != nil { // coverage-ignore
 				log.Printf("listener on port %d: %v", port, err) // coverage-ignore
 			} // coverage-ignore
-		}(portNumber) // coverage-ignore
+		}(spec.fd, spec.port) // coverage-ignore
 	} // coverage-ignore
 
 	wg.Wait()  // coverage-ignore

--- a/cissh_test.go
+++ b/cissh_test.go
@@ -31,14 +31,14 @@ platforms:
 }
 
 func TestRun_ZeroListeners(t *testing.T) {
-	cli := utils.CLI{Listeners: 0, StartingPort: 10000, TranscriptMap: validTranscriptMap(t)}
+	cli := utils.CLI{Listeners: 0, StartingPort: 10000, Platform: "csr1000v", TranscriptMap: validTranscriptMap(t)}
 	if err := run(context.Background(), cli); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
 }
 
 func TestRun_BadTranscriptMap(t *testing.T) {
-	cli := utils.CLI{Listeners: 0, StartingPort: 10000, TranscriptMap: "/nonexistent/file.yaml"}
+	cli := utils.CLI{Listeners: 0, StartingPort: 10000, Platform: "csr1000v", TranscriptMap: "/nonexistent/file.yaml"}
 	if err := run(context.Background(), cli); err == nil {
 		t.Error("expected error for missing transcript map")
 	}
@@ -60,9 +60,31 @@ platforms:
 	if err := os.WriteFile(tmpFile, []byte(content), 0644); err != nil {
 		t.Fatal(err)
 	}
-
-	cli := utils.CLI{Listeners: 0, StartingPort: 10000, TranscriptMap: tmpFile}
+	cli := utils.CLI{Listeners: 1, StartingPort: 10000, Platform: "csr1000v", TranscriptMap: tmpFile}
 	if err := run(context.Background(), cli); err == nil {
 		t.Error("expected error for bad transcript file reference")
+	}
+}
+
+func TestRun_BadInventory(t *testing.T) {
+	cli := utils.CLI{Platform: "csr1000v", TranscriptMap: validTranscriptMap(t), Inventory: "/nonexistent/inventory.yaml"}
+	if err := run(context.Background(), cli); err == nil {
+		t.Error("expected error for missing inventory file")
+	}
+}
+
+func TestRun_InventoryBadPlatform(t *testing.T) {
+	inv := `---
+devices:
+  - platform: nonexistent
+    count: 1
+`
+	invFile := filepath.Join(t.TempDir(), "inventory.yaml")
+	if err := os.WriteFile(invFile, []byte(inv), 0644); err != nil {
+		t.Fatal(err)
+	}
+	cli := utils.CLI{Platform: "csr1000v", TranscriptMap: validTranscriptMap(t), Inventory: invFile}
+	if err := run(context.Background(), cli); err == nil {
+		t.Error("expected error for nonexistent platform in inventory")
 	}
 }

--- a/fakedevices/genericFakeDevice.go
+++ b/fakedevices/genericFakeDevice.go
@@ -50,13 +50,11 @@ func readFile(filename string) (string, error) {
 }
 
 // InitGeneric builds a FakeDevice struct for use with cisshgo
-func InitGeneric(
-	vendor string,
-	platform string,
-	myTranscriptMap utils.TranscriptMap,
-) (*FakeDevice, error) {
-
-	p := myTranscriptMap.Platforms[platform]
+func InitGeneric(platform string, myTranscriptMap utils.TranscriptMap) (*FakeDevice, error) {
+	p, ok := myTranscriptMap.Platforms[platform]
+	if !ok {
+		return nil, fmt.Errorf("platform %q not found in transcript map", platform)
+	}
 
 	supportedCommands := make(SupportedCommands, len(p.CommandTranscripts))
 	for k, v := range p.CommandTranscripts {
@@ -67,9 +65,8 @@ func InitGeneric(
 		supportedCommands[k] = content
 	}
 
-	// Create our fake device and return it
-	myFakeDevice := FakeDevice{
-		Vendor:            vendor,
+	return &FakeDevice{
+		Vendor:            p.Vendor,
 		Platform:          platform,
 		Hostname:          p.Hostname,
 		DefaultHostname:   p.Hostname,
@@ -77,7 +74,5 @@ func InitGeneric(
 		SupportedCommands: supportedCommands,
 		ContextSearch:     p.ContextSearch,
 		ContextHierarchy:  p.ContextHierarchy,
-	}
-
-	return &myFakeDevice, nil
+	}, nil
 }

--- a/fakedevices/genericFakeDevice_test.go
+++ b/fakedevices/genericFakeDevice_test.go
@@ -38,7 +38,7 @@ func TestInitGeneric(t *testing.T) {
 	}
 	t.Cleanup(func() { os.Chdir("fakedevices") })
 
-	fd, err := InitGeneric("cisco", "csr1000v", testTranscriptMap())
+	fd, err := InitGeneric("csr1000v", testTranscriptMap())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -74,15 +74,9 @@ func TestInitGeneric_UnknownPlatform(t *testing.T) {
 			"other": {Hostname: "other"},
 		},
 	}
-	fd, err := InitGeneric("cisco", "csr1000v", tm)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if fd.Hostname != "" {
-		t.Errorf("Hostname = %q, want empty for unknown platform", fd.Hostname)
-	}
-	if len(fd.SupportedCommands) != 0 {
-		t.Errorf("SupportedCommands should be empty for unknown platform")
+	_, err := InitGeneric("csr1000v", tm)
+	if err == nil {
+		t.Error("expected error for unknown platform")
 	}
 }
 
@@ -134,7 +128,7 @@ func TestInitGeneric_BadTranscriptFile(t *testing.T) {
 			},
 		},
 	}
-	_, err := InitGeneric("cisco", "csr1000v", tm)
+	_, err := InitGeneric("csr1000v", tm)
 	if err == nil {
 		t.Error("expected error for missing transcript file")
 	}

--- a/transcripts/cisco/iosxr/show_version.txt
+++ b/transcripts/cisco/iosxr/show_version.txt
@@ -1,0 +1,25 @@
+Cisco IOS XR Software, Version 7.9.1
+Copyright (c) 2013-2023 by Cisco Systems, Inc.
+
+Build Information:
+ Built By     : aewinter
+ Built On     : Mon Oct  2 18:14:21 UTC 2023
+ Build Host   : iox-ucs-029
+ Workspace    : /auto/srcarchive17/prod/7.9.1/xr-dev/ws
+ Version      : 7.9.1
+ Location     : /opt/cisco/XR/packages/
+ Label        : 7.9.1
+
+cisco ASR9K Series (Intel 686 F6M14S4) processor with 12582912K bytes of memory.
+Intel 686 F6M14S4 processor at 2125MHz, Revision 2.174
+ASR-9001 Chassis
+
+2 Management Ethernet
+8 GigabitEthernet
+503k bytes of non-volatile configuration memory.
+3271M bytes of hard disk.
+11264M bytes of Flash system memory.
+
+Configuration register on node 0/RSP0/CPU0 is 0x102
+Boot device on node 0/RSP0/CPU0 is disk0:
+Package active on node 0/RSP0/CPU0:

--- a/transcripts/inventory_example.yaml
+++ b/transcripts/inventory_example.yaml
@@ -1,0 +1,6 @@
+---
+devices:
+  - platform: csr1000v
+    count: 10
+  - platform: iosxr
+    count: 5

--- a/transcripts/transcript_map.yaml
+++ b/transcripts/transcript_map.yaml
@@ -19,3 +19,16 @@ platforms:
       "configure terminal": "(config)#"
       "enable": "#"
       "base": ">"
+  iosxr:
+    vendor: "cisco"
+    hostname: "cisshgo-xr"
+    password: "admin"
+    command_transcripts:
+      "show version": "transcripts/cisco/iosxr/show_version.txt"
+      "terminal length 0": "transcripts/generic_empty_return.txt"
+    context_hierarchy:
+      "#": "exit"
+      "(config)#": "#"
+    context_search:
+      "configure terminal": "(config)#"
+      "base": "#"

--- a/utils/argparsing.go
+++ b/utils/argparsing.go
@@ -14,6 +14,32 @@ type CLI struct {
 	Listeners     int    `help:"How many listeners to spawn." default:"50" short:"l"`
 	StartingPort  int    `help:"Starting port." default:"10000" short:"p"`
 	TranscriptMap string `help:"Path to transcript map YAML file." default:"transcripts/transcript_map.yaml" short:"t" type:"path"`
+	Platform      string `help:"Platform to use when no inventory is provided." default:"csr1000v" short:"P"`
+	Inventory     string `help:"Path to inventory YAML file." optional:"" short:"i" type:"path"`
+}
+
+// InventoryEntry defines a single platform and how many listeners to spawn for it.
+type InventoryEntry struct {
+	Platform string `yaml:"platform"`
+	Count    int    `yaml:"count"`
+}
+
+// Inventory defines a set of devices to spawn.
+type Inventory struct {
+	Devices []InventoryEntry `yaml:"devices"`
+}
+
+// LoadInventory reads and parses an inventory YAML file.
+func LoadInventory(path string) (Inventory, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return Inventory{}, fmt.Errorf("reading inventory: %w", err)
+	}
+	var inv Inventory
+	if err = yaml.UnmarshalStrict(raw, &inv); err != nil {
+		return Inventory{}, fmt.Errorf("parsing inventory: %w", err)
+	}
+	return inv, nil
 }
 
 // TranscriptMapPlatform struct for use inside of a TranscriptMap struct

--- a/utils/argparsing_test.go
+++ b/utils/argparsing_test.go
@@ -122,3 +122,43 @@ func TestLoadTranscriptMap_InvalidYAML(t *testing.T) {
 		t.Error("expected error for invalid YAML")
 	}
 }
+
+func TestLoadInventory(t *testing.T) {
+	content := `---
+devices:
+  - platform: csr1000v
+    count: 10
+  - platform: iosxr
+    count: 5
+`
+	tmpFile := filepath.Join(t.TempDir(), "inventory.yaml")
+	if err := os.WriteFile(tmpFile, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+	inv, err := LoadInventory(tmpFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(inv.Devices) != 2 {
+		t.Fatalf("Devices len = %d, want 2", len(inv.Devices))
+	}
+	if inv.Devices[0].Platform != "csr1000v" || inv.Devices[0].Count != 10 {
+		t.Errorf("Devices[0] = %+v, want {csr1000v 10}", inv.Devices[0])
+	}
+}
+
+func TestLoadInventory_MissingFile(t *testing.T) {
+	_, err := LoadInventory("/nonexistent/inventory.yaml")
+	if err == nil {
+		t.Error("expected error for missing file")
+	}
+}
+
+func TestLoadInventory_InvalidYAML(t *testing.T) {
+	tmpFile := filepath.Join(t.TempDir(), "bad.yaml")
+	os.WriteFile(tmpFile, []byte(`not: valid: yaml: [[[`), 0644)
+	_, err := LoadInventory(tmpFile)
+	if err == nil {
+		t.Error("expected error for invalid YAML")
+	}
+}


### PR DESCRIPTION
Closes #43

## Summary

- `--inventory` flag for multi-device topology via YAML file
- `--platform` flag (default `csr1000v`) for single-device fallback
- `InitGeneric` now reads vendor from transcript map — vendor param removed
- `InitGeneric` returns error for unknown platform (previously silently returned empty device)
- Added `iosxr` platform to `transcript_map.yaml` with IOS XR 7.9.1 show version transcript
- Added `transcripts/inventory_example.yaml` demonstrating multi-device usage

## Breaking Change

`InitGeneric` signature changed: `vendor` parameter removed.