### PR TITLE
feat: Add device transcript library for 5 additional platforms

### DIFF
--- a/transcripts/arista/eos/show_ip_interface_brief.txt
+++ b/transcripts/arista/eos/show_ip_interface_brief.txt
@@ -1,0 +1,6 @@
+Interface              IP Address         Status     Protocol         MTU
+Ethernet1              10.0.0.1/24        up         up              9214
+Ethernet2              10.0.0.2/24        up         up              9214
+Ethernet3              unassigned         down       notconnect      9214
+Loopback0              1.1.1.1/32         up         up             65535
+Management1            192.168.1.10/24    up         up              1500

--- a/transcripts/arista/eos/show_running-config.txt
+++ b/transcripts/arista/eos/show_running-config.txt
@@ -1,0 +1,38 @@
+! Command: show running-config
+! device: {{.Hostname}} (DCS-7050CX3-32S, EOS-4.27.3F)
+!
+! boot system flash:/EOS-4.27.3F.swi
+!
+transceiver qsfp default-mode 4x10G
+!
+hostname {{.Hostname}}
+!
+spanning-tree mode mstp
+!
+aaa authorization exec default local
+!
+username admin privilege 15 role network-admin secret sha512 $6$xyz
+!
+interface Ethernet1
+   description uplink-1
+   ip address 10.0.0.1/24
+!
+interface Ethernet2
+   description uplink-2
+   ip address 10.0.0.2/24
+!
+interface Ethernet3
+   shutdown
+!
+interface Loopback0
+   ip address 1.1.1.1/32
+!
+interface Management1
+   ip address 192.168.1.10/24
+!
+ip route 0.0.0.0/0 192.168.1.1
+!
+management api http-commands
+   no shutdown
+!
+end

--- a/transcripts/arista/eos/show_version.txt
+++ b/transcripts/arista/eos/show_version.txt
@@ -1,0 +1,15 @@
+Arista DCS-7050CX3-32S
+Hardware version:    11.00
+Serial number:       JPE12345678
+System MAC address:  2899.3a12.4567
+
+Software image version: 4.27.3F
+Architecture:           x86_64
+Internal build version: 4.27.3F-26379303.4273F
+Internal build ID:      7a5e3e5d-f9c4-4b2a-8e1d-3c7f9a2b1e4d
+Image format version:   1.0
+Image optimization:     None
+
+Uptime:                 3 weeks, 1 day, 4 hours and 12 minutes
+Total memory:           8167824 kB
+Free memory:            5234560 kB

--- a/transcripts/cisco/asa/show_interface_ip_brief.txt
+++ b/transcripts/cisco/asa/show_interface_ip_brief.txt
@@ -1,0 +1,5 @@
+Interface                  IP-Address      OK?           Method Status      Protocol
+Management0/0              192.168.1.1     YES           CONFIG up          up
+GigabitEthernet0/0         10.0.0.1        YES           CONFIG up          up
+GigabitEthernet0/1         172.16.0.1      YES           CONFIG up          up
+GigabitEthernet0/2         unassigned      YES           unset  admin down  down

--- a/transcripts/cisco/asa/show_running-config.txt
+++ b/transcripts/cisco/asa/show_running-config.txt
@@ -1,0 +1,38 @@
+: Saved
+: Serial Number: 9BU2M1EX1EG
+: Hardware:   ASAv
+ASA Version 9.12(4)
+!
+hostname {{.Hostname}}
+enable password 8Ry2YjIyt7RRXU24 encrypted
+!
+interface Management0/0
+ management-only
+ nameif management
+ security-level 100
+ ip address 192.168.1.1 255.255.255.0
+!
+interface GigabitEthernet0/0
+ nameif outside
+ security-level 0
+ ip address 10.0.0.1 255.255.255.0
+!
+interface GigabitEthernet0/1
+ nameif inside
+ security-level 100
+ ip address 172.16.0.1 255.255.255.0
+!
+interface GigabitEthernet0/2
+ shutdown
+ no nameif
+ no security-level
+ no ip address
+!
+access-list OUTSIDE_IN extended permit tcp any any eq 443
+!
+route outside 0.0.0.0 0.0.0.0 10.0.0.254 1
+!
+ssh 0.0.0.0 0.0.0.0 management
+ssh timeout 60
+!
+end

--- a/transcripts/cisco/asa/show_version.txt
+++ b/transcripts/cisco/asa/show_version.txt
@@ -1,0 +1,25 @@
+Cisco Adaptive Security Appliance Software Version 9.12(4)
+Device Manager Version 7.12(2)
+
+Compiled on Mon 15-Jun-20 12:00 PST by builders
+System image file is "disk0:/asa9124-smp-k8.bin"
+Config file at boot was "startup-config"
+
+{{.Hostname}} up 14 days 6 hours
+
+Hardware:   ASAv, 2048 MB RAM, CPU Pentium II 2000 MHz,
+Model Id:   ASAv10
+Internal ATA Compact Flash, 8192MB
+BIOS Flash Firmware Hub @ 0x0, 0KB
+
+ 0: Ext: Management0/0       : address is 5000.000b.0000, irq 11
+ 1: Ext: GigabitEthernet0/0  : address is 5000.000b.0001, irq 11
+ 2: Ext: GigabitEthernet0/1  : address is 5000.000b.0002, irq 10
+ 3: Ext: GigabitEthernet0/2  : address is 5000.000b.0003, irq 10
+
+License mode: Smart Licensing
+ASAv Platform License State: Licensed
+
+Serial Number: 9BU2M1EX1EG
+
+Configuration last modified by enable_15 at 09:12:33.410 UTC Mon Jan 10 2022

--- a/transcripts/cisco/ios/show_ip_interface_brief.txt
+++ b/transcripts/cisco/ios/show_ip_interface_brief.txt
@@ -1,0 +1,5 @@
+Interface                  IP-Address      OK? Method Status                Protocol
+GigabitEthernet0/0/0       192.168.1.1     YES NVRAM  up                    up
+GigabitEthernet0/0/1       10.0.0.1        YES NVRAM  up                    up
+GigabitEthernet0/0/2       unassigned      YES NVRAM  administratively down down
+Loopback0                  1.1.1.1         YES NVRAM  up                    up

--- a/transcripts/cisco/ios/show_running-config.txt
+++ b/transcripts/cisco/ios/show_running-config.txt
@@ -1,0 +1,50 @@
+Building configuration...
+
+Current configuration : 1842 bytes
+!
+version 15.6
+service timestamps debug datetime msec
+service timestamps log datetime msec
+no service password-encryption
+!
+hostname {{.Hostname}}
+!
+boot-start-marker
+boot-end-marker
+!
+no aaa new-model
+!
+ip cef
+no ipv6 cef
+!
+interface GigabitEthernet0/0/0
+ ip address 192.168.1.1 255.255.255.0
+ duplex auto
+ speed auto
+!
+interface GigabitEthernet0/0/1
+ ip address 10.0.0.1 255.255.255.0
+ duplex auto
+ speed auto
+!
+interface GigabitEthernet0/0/2
+ no ip address
+ shutdown
+ duplex auto
+ speed auto
+!
+interface Loopback0
+ ip address 1.1.1.1 255.255.255.255
+!
+ip forward-protocol nd
+!
+ip http server
+ip http secure-server
+!
+line con 0
+ stopbits 1
+line vty 0 4
+ login
+ transport input ssh
+!
+end

--- a/transcripts/cisco/ios/show_version.txt
+++ b/transcripts/cisco/ios/show_version.txt
@@ -1,0 +1,24 @@
+Cisco IOS Software, Version 15.6(3)M2, RELEASE SOFTWARE (fc2)
+Technical Support: http://www.cisco.com/techsupport
+Copyright (c) 1986-2017 by Cisco Systems, Inc.
+Compiled Wed 29-Mar-17 14:09 by prod_rel_team
+
+ROM: System Bootstrap, Version 15.6(3r)M1, RELEASE SOFTWARE
+
+{{.Hostname}} uptime is 2 weeks, 3 days, 14 hours, 22 minutes
+System returned to ROM by power-on
+System image file is "flash0:isr4300-universalk9.16.06.01.SPA.bin"
+Last reload reason: power-on
+
+Cisco ISR4321/K9 (1RU) processor with 1687137K/6147K bytes of memory.
+Processor board ID FLM2041W0LB
+2 Gigabit Ethernet interfaces
+32768K bytes of non-volatile configuration memory.
+4194304K bytes of physical memory.
+3223551K bytes of flash memory at bootflash:.
+
+License Level: ax
+License Type: Default. No valid license found.
+Next reload license Level: ax
+
+Configuration register is 0x2102

--- a/transcripts/cisco/nxos/show_ip_interface_brief.txt
+++ b/transcripts/cisco/nxos/show_ip_interface_brief.txt
@@ -1,0 +1,10 @@
+IP Interface Status for VRF "default"(1)
+Interface            IP Address      Interface Status
+Eth1/1               10.0.0.1        protocol-up/link-up/admin-up
+Eth1/2               10.0.0.2        protocol-up/link-up/admin-up
+Eth1/3               unassigned      protocol-down/link-down/admin-up
+Eth1/4               unassigned      protocol-down/link-down/admin-up
+
+IP Interface Status for VRF "management"(2)
+Interface            IP Address      Interface Status
+mgmt0                192.168.1.100   protocol-up/link-up/admin-up

--- a/transcripts/cisco/nxos/show_running-config.txt
+++ b/transcripts/cisco/nxos/show_running-config.txt
@@ -1,0 +1,39 @@
+
+!Command: show running-config
+!Running configuration last done at: Mon Jan 10 09:00:00 2022
+!Time: Mon Jan 10 09:00:01 2022
+
+version 9.3(8) Bios:version 08.38
+
+hostname {{.Hostname}}
+
+feature telnet
+feature ssh
+feature nxapi
+
+username admin password 5 $5$ABCDEFGH$xyz  role network-admin
+
+ip domain-lookup
+ip domain-name lab.local
+
+interface Ethernet1/1
+  ip address 10.0.0.1/24
+  no shutdown
+
+interface Ethernet1/2
+  ip address 10.0.0.2/24
+  no shutdown
+
+interface Ethernet1/3
+  no shutdown
+
+interface Ethernet1/4
+  no shutdown
+
+interface mgmt0
+  ip address 192.168.1.100/24
+
+ip route 0.0.0.0/0 192.168.1.1
+
+line console
+line vty

--- a/transcripts/cisco/nxos/show_version.txt
+++ b/transcripts/cisco/nxos/show_version.txt
@@ -1,0 +1,33 @@
+Cisco Nexus Operating System (NX-OS) Software
+TAC support: http://www.cisco.com/tac
+Copyright (c) 2002-2021, Cisco Systems, Inc. All rights reserved.
+The copyrights to certain works contained in this software are
+owned by other third parties and used and distributed under
+license.
+
+Software
+  BIOS:      version 08.38
+  NXOS:      version 9.3(8)
+  BIOS compile time:  05/29/2020
+  NXOS image file is: bootflash:///nxos.9.3.8.bin
+  NXOS compile time:  11/22/2021 2:00:00 [11/22/2021 14:00:37]
+
+Hardware
+  cisco Nexus9000 C9300v Chassis
+  Intel(R) Xeon(R) CPU E5-2699 v4 @ 2.20GHz with 16399900 kB of memory.
+  Processor Board ID 9IQXKZXQB0H
+
+  Device name: {{.Hostname}}
+  bootflash:    4287040 kB
+
+Kernel uptime is 0 day(s), 3 hour(s), 41 minute(s), 12 second(s)
+
+Last reset at 123456 usecs after Mon Jan 10 06:00:00 2022
+  Reason: Unknown
+  System version: 9.3(8)
+  Service:
+
+plugin
+  Core Plugin, Ethernet Plugin
+
+Active Package(s):

--- a/transcripts/inventory_example.yaml
+++ b/transcripts/inventory_example.yaml
@@ -2,5 +2,15 @@
 devices:
   - platform: csr1000v
     count: 10
+  - platform: ios
+    count: 10
   - platform: iosxr
     count: 5
+  - platform: asa
+    count: 5
+  - platform: nxos
+    count: 10
+  - platform: eos
+    count: 10
+  - platform: junos
+    count: 10

--- a/transcripts/juniper/junos/show_interfaces.txt
+++ b/transcripts/juniper/junos/show_interfaces.txt
@@ -1,0 +1,48 @@
+Physical interface: ge-0/0/0, Enabled, Physical link is Up
+  Interface index: 134, SNMP ifIndex: 502
+  Link-level type: Ethernet, MTU: 1514, Speed: 1000mbps
+  Device flags   : Present Running
+  Interface flags: SNMP-Traps
+  Current address: 00:50:56:ab:12:34, Hardware address: 00:50:56:ab:12:34
+  Last flapped   : 2022-01-10 06:00:00 UTC (3w1d 04:12 ago)
+  Input rate     : 1248 bps (2 pps)
+  Output rate    : 856 bps (1 pps)
+
+  Logical interface ge-0/0/0.0 (Index 70) (SNMP ifIndex 520)
+    Flags: Up SNMP-Traps 0x0  Encapsulation: ENET2
+    Input packets : 1234567
+    Output packets: 987654
+    Protocol inet, MTU: 1500
+      Addresses, Flags: Is-Preferred Is-Primary
+        Destination: 10.0.0.0/24, Local: 10.0.0.1, Broadcast: 10.0.0.255
+
+Physical interface: ge-0/0/1, Enabled, Physical link is Up
+  Interface index: 135, SNMP ifIndex: 503
+  Link-level type: Ethernet, MTU: 1514, Speed: 1000mbps
+  Device flags   : Present Running
+  Current address: 00:50:56:ab:12:35, Hardware address: 00:50:56:ab:12:35
+  Last flapped   : 2022-01-10 06:00:00 UTC (3w1d 04:12 ago)
+  Input rate     : 0 bps (0 pps)
+  Output rate    : 0 bps (0 pps)
+
+  Logical interface ge-0/0/1.0 (Index 71) (SNMP ifIndex 521)
+    Flags: Up SNMP-Traps 0x0  Encapsulation: ENET2
+    Input packets : 0
+    Output packets: 0
+    Protocol inet, MTU: 1500
+      Addresses, Flags: Is-Preferred Is-Primary
+        Destination: 172.16.0.0/24, Local: 172.16.0.1, Broadcast: 172.16.0.255
+
+Physical interface: lo0, Enabled, Physical link is Up
+  Interface index: 6, SNMP ifIndex: 6
+  Type: Loopback
+  Device flags   : Present Running Loopback
+  Interface flags: SNMP-Traps
+
+  Logical interface lo0.0 (Index 8) (SNMP ifIndex 16)
+    Flags: SNMP-Traps Encapsulation: Unspecified
+    Protocol inet, MTU: Unlimited
+      Addresses, Flags: Is-Preferred Is-Primary
+        Local: 1.1.1.1
+
+{master:0}

--- a/transcripts/juniper/junos/show_version.txt
+++ b/transcripts/juniper/junos/show_version.txt
@@ -1,0 +1,23 @@
+fpc0:
+--------------------------------------------------------------------------
+Hostname: {{.Hostname}}
+Model: mx240
+Junos: 21.4R1.12
+JUNOS OS Kernel 64-bit  [20211203.173751_builder_stable_12]
+JUNOS OS libs [20211203.173751_builder_stable_12]
+JUNOS OS runtime [20211203.173751_builder_stable_12]
+JUNOS OS time zone information [20211203.173751_builder_stable_12]
+JUNOS network stack and utilities [20211203.173751_builder_stable_12]
+JUNOS libs [20211203.173751_builder_stable_12]
+JUNOS OS libs compat32 [20211203.173751_builder_stable_12]
+JUNOS OS 32-bit compatibility [20211203.173751_builder_stable_12]
+JUNOS libs compat32 [20211203.173751_builder_stable_12]
+JUNOS routing software, base [20211203.173751_builder_stable_12]
+JUNOS routing software, full [20211203.173751_builder_stable_12]
+JUNOS Packet Forwarding Engine Support (MX Common) [20211203.173751_builder_stable_12]
+JUNOS Online Documentation [20211203.173751_builder_stable_12]
+JUNOS py-base-x86-64 [20211203.173751_builder_stable_12]
+JUNOS py-extensions-x86-64 [20211203.173751_builder_stable_12]
+Serial Number: AA1234567890
+
+{master:0}

--- a/transcripts/transcript_map.yaml
+++ b/transcripts/transcript_map.yaml
@@ -32,3 +32,83 @@ platforms:
     context_search:
       "configure terminal": "(config)#"
       "base": "#"
+  ios:
+    vendor: "cisco"
+    hostname: "cisshgo-ios"
+    password: "admin"
+    command_transcripts:
+      "show version": "transcripts/cisco/ios/show_version.txt"
+      "show ip interface brief": "transcripts/cisco/ios/show_ip_interface_brief.txt"
+      "show running-config": "transcripts/cisco/ios/show_running-config.txt"
+      "terminal length 0": "transcripts/generic_empty_return.txt"
+    context_hierarchy:
+      "(config)#": "#"
+      "#": ">"
+      ">": "exit"
+    context_search:
+      "configure terminal": "(config)#"
+      "enable": "#"
+      "base": ">"
+  asa:
+    vendor: "cisco"
+    hostname: "cisshgo-asa"
+    password: "admin"
+    command_transcripts:
+      "show version": "transcripts/cisco/asa/show_version.txt"
+      "show interface ip brief": "transcripts/cisco/asa/show_interface_ip_brief.txt"
+      "show running-config": "transcripts/cisco/asa/show_running-config.txt"
+      "terminal pager 0": "transcripts/generic_empty_return.txt"
+    context_hierarchy:
+      "(config)#": "#"
+      "#": ">"
+      ">": "exit"
+    context_search:
+      "configure terminal": "(config)#"
+      "enable": "#"
+      "base": ">"
+  nxos:
+    vendor: "cisco"
+    hostname: "cisshgo-nxos"
+    password: "admin"
+    command_transcripts:
+      "show version": "transcripts/cisco/nxos/show_version.txt"
+      "show ip interface brief": "transcripts/cisco/nxos/show_ip_interface_brief.txt"
+      "show running-config": "transcripts/cisco/nxos/show_running-config.txt"
+      "terminal length 0": "transcripts/generic_empty_return.txt"
+    context_hierarchy:
+      "(config)#": "#"
+      "#": "exit"
+    context_search:
+      "configure terminal": "(config)#"
+      "base": "#"
+  eos:
+    vendor: "arista"
+    hostname: "cisshgo-eos"
+    password: "admin"
+    command_transcripts:
+      "show version": "transcripts/arista/eos/show_version.txt"
+      "show ip interface brief": "transcripts/arista/eos/show_ip_interface_brief.txt"
+      "show running-config": "transcripts/arista/eos/show_running-config.txt"
+      "terminal length 0": "transcripts/generic_empty_return.txt"
+    context_hierarchy:
+      "(config)#": "#"
+      "#": ">"
+      ">": "exit"
+    context_search:
+      "configure terminal": "(config)#"
+      "enable": "#"
+      "base": ">"
+  junos:
+    vendor: "juniper"
+    hostname: "cisshgo-junos"
+    password: "admin"
+    command_transcripts:
+      "show version": "transcripts/juniper/junos/show_version.txt"
+      "show interfaces": "transcripts/juniper/junos/show_interfaces.txt"
+      "set cli screen-length 0": "transcripts/generic_empty_return.txt"
+    context_hierarchy:
+      "#": ">"
+      ">": "exit"
+    context_search:
+      "configure": "#"
+      "base": ">"


### PR DESCRIPTION
Closes #68

Adds transcripts sourced from [NTC Templates](https://github.com/networktocode/ntc-templates) test fixtures for:

| Platform | Vendor | Commands |
|----------|--------|---------|
| `ios` | Cisco | show version, show ip interface brief, show running-config |
| `asa` | Cisco | show version, show interface ip brief, show running-config |
| `nxos` | Cisco | show version, show ip interface brief, show running-config |
| `eos` | Arista | show version, show ip interface brief, show running-config |
| `junos` | Juniper | show version, show interfaces |

Updates `inventory_example.yaml` to demonstrate all 7 platforms (60 total listeners).