### PR TITLE
feat: Add --version flag to display version information

### DIFF
--- a/cissh.go
+++ b/cissh.go
@@ -8,6 +8,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"os/signal"
 	"path/filepath"
@@ -21,6 +22,12 @@ import (
 	"github.com/tbotnz/cisshgo/ssh_server/handlers"
 	"github.com/tbotnz/cisshgo/ssh_server/sshlisteners"
 	"github.com/tbotnz/cisshgo/transcript"
+)
+
+var (
+	version = "dev"
+	commit  = "none"
+	date    = "unknown"
 )
 
 type listenerConfig struct {
@@ -115,6 +122,9 @@ func main() { // coverage-ignore
 	kong.Parse(&cli,
 		kong.Name("cisshgo"),
 		kong.Description("Lightweight SSH server that emulates network equipment for testing."),
+		kong.Vars{
+			"version": fmt.Sprintf("%s (commit: %s, built: %s)", version, commit, date),
+		},
 	)
 
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)

--- a/config/config.go
+++ b/config/config.go
@@ -5,16 +5,18 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/alecthomas/kong"
 	"gopkg.in/yaml.v2"
 )
 
 // CLI defines the command-line interface for cisshgo.
 type CLI struct {
-	Listeners     int    `help:"How many listeners to spawn." default:"50" short:"l" env:"CISSHGO_LISTENERS"`
-	StartingPort  int    `help:"Starting port." default:"10000" short:"p" env:"CISSHGO_STARTING_PORT"`
-	TranscriptMap string `help:"Path to transcript map YAML file." default:"transcripts/transcript_map.yaml" short:"t" type:"path" env:"CISSHGO_TRANSCRIPT_MAP"`
-	Platform      string `help:"Platform to use when no inventory is provided." default:"csr1000v" short:"P" env:"CISSHGO_PLATFORM"`
-	Inventory     string `help:"Path to inventory YAML file." optional:"" short:"i" type:"path" env:"CISSHGO_INVENTORY"`
+	Version       kong.VersionFlag `short:"v" help:"Show version information."`
+	Listeners     int              `help:"How many listeners to spawn." default:"50" short:"l" env:"CISSHGO_LISTENERS"`
+	StartingPort  int              `help:"Starting port." default:"10000" short:"p" env:"CISSHGO_STARTING_PORT"`
+	TranscriptMap string           `help:"Path to transcript map YAML file." default:"transcripts/transcript_map.yaml" short:"t" type:"path" env:"CISSHGO_TRANSCRIPT_MAP"`
+	Platform      string           `help:"Platform to use when no inventory is provided." default:"csr1000v" short:"P" env:"CISSHGO_PLATFORM"`
+	Inventory     string           `help:"Path to inventory YAML file." optional:"" short:"i" type:"path" env:"CISSHGO_INVENTORY"`
 }
 
 // InventoryEntry defines a single platform or scenario and how many listeners to spawn.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -6,6 +6,7 @@ Complete reference for all cisshgo command-line flags and environment variables.
 
 | Flag | Short | Default | Description |
 |------|-------|---------|-------------|
+| `--version` | `-v` | - | Show version information |
 | `--listeners` | `-l` | `50` | Number of SSH listeners to spawn |
 | `--starting-port` | `-p` | `10000` | Starting port number |
 | `--transcript-map` | `-t` | `transcripts/transcript_map.yaml` | Path to transcript map file |
@@ -19,6 +20,21 @@ cisshgo [flags]
 ```
 
 ## Flags
+
+### -v, --version
+
+Show version information including commit hash and build date.
+
+```bash
+# Show version
+./cisshgo --version
+./cisshgo -v
+```
+
+Output:
+```text
+1.0.0 (commit: abc123def, built: 2026-03-01T12:00:00Z)
+```
 
 ### -l, --listeners
 


### PR DESCRIPTION
Closes #87

## Summary

Adds `--version` / `-v` flag to display cisshgo version information including commit hash and build date.

## Changes

- Add `Version` field to CLI struct with `kong.VersionFlag`
- Add version variables (`version`, `commit`, `date`) set via ldflags
- Update Kong parser to include version vars
- Add version flag documentation to CLI reference
- GoReleaser already configured with ldflags (no changes needed)

## Usage

```bash
./cisshgo --version
./cisshgo -v
```

## Output

Development build:
```
dev (commit: none, built: unknown)
```

Release build:
```
1.0.0 (commit: abc123def, built: 2026-03-01T12:00:00Z)
```

## Testing

Tested locally with:
```bash
go run -ldflags "-X main.version=dev -X main.commit=test123 -X main.date=$(date -u +%Y-%m-%dT%H:%M:%SZ)" cissh.go --version
```

Output: `dev (commit: test123, built: 2026-03-01T01:41:15Z)`