### PR TITLE
fix: Correct transcript paths to be relative to map file directory

### DIFF
--- a/fakedevices/genericFakeDevice_test.go
+++ b/fakedevices/genericFakeDevice_test.go
@@ -148,21 +148,25 @@ func TestTranscriptMapIntegrity(t *testing.T) {
 	}
 
 	// Track all referenced paths for orphan detection
+	// Paths in the map are relative to the map file's directory (transcripts/)
+	const mapDir = "transcripts"
 	referenced := map[string]bool{}
 
 	for platform, p := range tm.Platforms {
 		for cmd, path := range p.CommandTranscripts {
-			referenced[path] = true
-			if _, err := os.Stat(path); err != nil {
-				t.Errorf("platform %q command %q: file not found: %s", platform, cmd, path)
+			resolved := filepath.Join(mapDir, path)
+			referenced[resolved] = true
+			if _, err := os.Stat(resolved); err != nil {
+				t.Errorf("platform %q command %q: file not found: %s", platform, cmd, resolved)
 			}
 		}
 	}
 	for name, s := range tm.Scenarios {
 		for i, step := range s.Sequence {
-			referenced[step.Transcript] = true
-			if _, err := os.Stat(step.Transcript); err != nil {
-				t.Errorf("scenario %q step %d (%q): file not found: %s", name, i, step.Command, step.Transcript)
+			resolved := filepath.Join(mapDir, step.Transcript)
+			referenced[resolved] = true
+			if _, err := os.Stat(resolved); err != nil {
+				t.Errorf("scenario %q step %d (%q): file not found: %s", name, i, step.Command, resolved)
 			}
 		}
 	}
@@ -197,7 +201,7 @@ func TestInitScenario(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	fd, steps, err := InitScenario("csr1000v-add-interface", tm, ".")
+	fd, steps, err := InitScenario("csr1000v-add-interface", tm, "transcripts")
 	if err != nil {
 		t.Fatalf("InitScenario: %v", err)
 	}

--- a/transcripts/transcript_map.yaml
+++ b/transcripts/transcript_map.yaml
@@ -5,12 +5,12 @@ platforms:
     hostname: "cisshgo1000v"
     password: "admin"
     command_transcripts:
-      "show ip interface brief": "transcripts/cisco/csr1000v/show_ip_interface_brief.txt"
-      "show running-config": "transcripts/cisco/csr1000v/show_running-config.txt"
-      "show version": "transcripts/cisco/csr1000v/show_version.txt"
-      "terminal length 0": "transcripts/generic_empty_return.txt"
-      "terminal width 511": "transcripts/generic_empty_return.txt"
-      "write mem": "transcripts/cisco/csr1000v/write_mem.txt"
+      "show ip interface brief": "cisco/csr1000v/show_ip_interface_brief.txt"
+      "show running-config": "cisco/csr1000v/show_running-config.txt"
+      "show version": "cisco/csr1000v/show_version.txt"
+      "terminal length 0": "generic_empty_return.txt"
+      "terminal width 511": "generic_empty_return.txt"
+      "write mem": "cisco/csr1000v/write_mem.txt"
     context_hierarchy:
       "(config)#": "#"
       "#": ">"
@@ -24,8 +24,8 @@ platforms:
     hostname: "cisshgo-xr"
     password: "admin"
     command_transcripts:
-      "show version": "transcripts/cisco/iosxr/show_version.txt"
-      "terminal length 0": "transcripts/generic_empty_return.txt"
+      "show version": "cisco/iosxr/show_version.txt"
+      "terminal length 0": "generic_empty_return.txt"
     context_hierarchy:
       "#": "exit"
       "(config)#": "#"
@@ -37,10 +37,10 @@ platforms:
     hostname: "cisshgo-ios"
     password: "admin"
     command_transcripts:
-      "show version": "transcripts/cisco/ios/show_version.txt"
-      "show ip interface brief": "transcripts/cisco/ios/show_ip_interface_brief.txt"
-      "show running-config": "transcripts/cisco/ios/show_running-config.txt"
-      "terminal length 0": "transcripts/generic_empty_return.txt"
+      "show version": "cisco/ios/show_version.txt"
+      "show ip interface brief": "cisco/ios/show_ip_interface_brief.txt"
+      "show running-config": "cisco/ios/show_running-config.txt"
+      "terminal length 0": "generic_empty_return.txt"
     context_hierarchy:
       "(config)#": "#"
       "#": ">"
@@ -54,10 +54,10 @@ platforms:
     hostname: "cisshgo-asa"
     password: "admin"
     command_transcripts:
-      "show version": "transcripts/cisco/asa/show_version.txt"
-      "show interface ip brief": "transcripts/cisco/asa/show_interface_ip_brief.txt"
-      "show running-config": "transcripts/cisco/asa/show_running-config.txt"
-      "terminal pager 0": "transcripts/generic_empty_return.txt"
+      "show version": "cisco/asa/show_version.txt"
+      "show interface ip brief": "cisco/asa/show_interface_ip_brief.txt"
+      "show running-config": "cisco/asa/show_running-config.txt"
+      "terminal pager 0": "generic_empty_return.txt"
     context_hierarchy:
       "(config)#": "#"
       "#": ">"
@@ -71,10 +71,10 @@ platforms:
     hostname: "cisshgo-nxos"
     password: "admin"
     command_transcripts:
-      "show version": "transcripts/cisco/nxos/show_version.txt"
-      "show ip interface brief": "transcripts/cisco/nxos/show_ip_interface_brief.txt"
-      "show running-config": "transcripts/cisco/nxos/show_running-config.txt"
-      "terminal length 0": "transcripts/generic_empty_return.txt"
+      "show version": "cisco/nxos/show_version.txt"
+      "show ip interface brief": "cisco/nxos/show_ip_interface_brief.txt"
+      "show running-config": "cisco/nxos/show_running-config.txt"
+      "terminal length 0": "generic_empty_return.txt"
     context_hierarchy:
       "(config)#": "#"
       "#": "exit"
@@ -86,10 +86,10 @@ platforms:
     hostname: "cisshgo-eos"
     password: "admin"
     command_transcripts:
-      "show version": "transcripts/arista/eos/show_version.txt"
-      "show ip interface brief": "transcripts/arista/eos/show_ip_interface_brief.txt"
-      "show running-config": "transcripts/arista/eos/show_running-config.txt"
-      "terminal length 0": "transcripts/generic_empty_return.txt"
+      "show version": "arista/eos/show_version.txt"
+      "show ip interface brief": "arista/eos/show_ip_interface_brief.txt"
+      "show running-config": "arista/eos/show_running-config.txt"
+      "terminal length 0": "generic_empty_return.txt"
     context_hierarchy:
       "(config)#": "#"
       "#": ">"
@@ -105,9 +105,9 @@ platforms:
     password: "admin"
     prompt_format: "{username}@{hostname}{context}"
     command_transcripts:
-      "show version": "transcripts/juniper/junos/show_version.txt"
-      "show interfaces": "transcripts/juniper/junos/show_interfaces.txt"
-      "set cli screen-length 0": "transcripts/generic_empty_return.txt"
+      "show version": "juniper/junos/show_version.txt"
+      "show interfaces": "juniper/junos/show_interfaces.txt"
+      "set cli screen-length 0": "generic_empty_return.txt"
     context_hierarchy:
       "#": ">"
       ">": "exit"
@@ -122,12 +122,12 @@ scenarios:
     platform: csr1000v
     sequence:
       - command: "show running-config"
-        transcript: "transcripts/scenarios/csr1000v-add-interface/running_config_before.txt"
+        transcript: "scenarios/csr1000v-add-interface/running_config_before.txt"
       - command: "interface GigabitEthernet0/0/2"
-        transcript: "transcripts/generic_empty_return.txt"
+        transcript: "generic_empty_return.txt"
       - command: "ip address 172.16.0.1 255.255.255.0"
-        transcript: "transcripts/generic_empty_return.txt"
+        transcript: "generic_empty_return.txt"
       - command: "end"
-        transcript: "transcripts/generic_empty_return.txt"
+        transcript: "generic_empty_return.txt"
       - command: "show running-config"
-        transcript: "transcripts/scenarios/csr1000v-add-interface/running_config_after.txt"
+        transcript: "scenarios/csr1000v-add-interface/running_config_after.txt"


### PR DESCRIPTION
Paths in transcript_map.yaml were prefixed with `transcripts/` but since #72 they are resolved relative to the map file's own directory. This caused a double `transcripts/transcripts/` path at runtime.

Also updates `TestTranscriptMapIntegrity` and `TestInitScenario` to resolve paths correctly in tests.