### PR TITLE
fix: Move enable to first step in csr1000v-add-interface scenario

### DIFF
--- a/fakedevices/genericFakeDevice_test.go
+++ b/fakedevices/genericFakeDevice_test.go
@@ -211,8 +211,8 @@ func TestInitScenario(t *testing.T) {
 	if len(steps) != 8 {
 		t.Errorf("steps len = %d, want 8", len(steps))
 	}
-	if steps[0].Command != "show running-config" {
-		t.Errorf("steps[0].Command = %q, want 'show running-config'", steps[0].Command)
+	if steps[0].Command != "enable" {
+		t.Errorf("steps[0].Command = %q, want 'enable'", steps[0].Command)
 	}
 }
 

--- a/transcripts/transcript_map.yaml
+++ b/transcripts/transcript_map.yaml
@@ -143,10 +143,10 @@ scenarios:
   csr1000v-add-interface:
     platform: csr1000v
     sequence:
-      - command: "show running-config"
-        transcript: "scenarios/csr1000v-add-interface/running_config_before.txt"
       - command: "enable"
         transcript: "generic_empty_return.txt"
+      - command: "show running-config"
+        transcript: "scenarios/csr1000v-add-interface/running_config_before.txt"
       - command: "configure terminal"
         transcript: "generic_empty_return.txt"
       - command: "interface GigabitEthernet0/0/2"


### PR DESCRIPTION
show running-config requires privileged exec on real IOS. Reorder so enable comes first.