### PR TITLE
fix: Update csr1000v-add-interface scenario transcripts and steps

### DIFF
--- a/fakedevices/genericFakeDevice_test.go
+++ b/fakedevices/genericFakeDevice_test.go
@@ -208,8 +208,8 @@ func TestInitScenario(t *testing.T) {
 	if fd.Platform != "csr1000v" {
 		t.Errorf("Platform = %q, want csr1000v", fd.Platform)
 	}
-	if len(steps) != 8 {
-		t.Errorf("steps len = %d, want 8", len(steps))
+	if len(steps) != 9 {
+		t.Errorf("steps len = %d, want 9", len(steps))
 	}
 	if steps[0].Command != "enable" {
 		t.Errorf("steps[0].Command = %q, want 'enable'", steps[0].Command)

--- a/transcripts/scenarios/csr1000v-add-interface/running_config_after.txt
+++ b/transcripts/scenarios/csr1000v-add-interface/running_config_after.txt
@@ -12,7 +12,7 @@ interface GigabitEthernet0/0/1
  ip address 10.0.0.1 255.255.255.0
 !
 interface GigabitEthernet0/0/2
- ip address 172.16.0.1 255.255.255.0
  description added-in-scenario
+ ip address 172.16.0.1 255.255.255.0
 !
 end

--- a/transcripts/scenarios/csr1000v-add-interface/running_config_before.txt
+++ b/transcripts/scenarios/csr1000v-add-interface/running_config_before.txt
@@ -11,4 +11,8 @@ interface GigabitEthernet0/0/0
 interface GigabitEthernet0/0/1
  ip address 10.0.0.1 255.255.255.0
 !
+interface GigabitEthernet0/0/2
+ no ip address
+ shutdown
+!
 end

--- a/transcripts/transcript_map.yaml
+++ b/transcripts/transcript_map.yaml
@@ -153,6 +153,8 @@ scenarios:
         transcript: "generic_empty_return.txt"
       - command: "ip address 172.16.0.1 255.255.255.0"
         transcript: "generic_empty_return.txt"
+      - command: "description added-in-scenario"
+        transcript: "generic_empty_return.txt"
       - command: "no shutdown"
         transcript: "generic_empty_return.txt"
       - command: "end"


### PR DESCRIPTION
- Add GigabitEthernet0/0/2 in shutdown/no-ip state to before transcript
- Fix description ordering in after transcript (IOS puts description before ip address)
- Add 'description added-in-scenario' as sequence step