### PR TITLE
Issue-110

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -82,7 +82,7 @@ With default settings (50 listeners, starting port 10000), listeners run on port
 **Default**: `transcripts/transcript_map.yaml`  
 **Environment**: `CISSHGO_TRANSCRIPT_MAP`
 
-Path to the transcript map YAML file.
+Path to the transcript map file.
 
 ```bash
 # Use custom transcript map

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2,12 +2,12 @@
 
 cisshgo uses YAML files for configuration. There are two types of configuration files:
 
-1. **Transcript Map** - Defines platforms, commands, and CLI contexts
+1. **Transcript map** - Defines platforms, commands, and CLI contexts
 2. **Inventory** - Defines multi-device topologies
 
 ## Transcript Map
 
-The transcript map (`transcripts/transcript_map.yaml`) defines available platforms and their command responses.
+The transcript map file (`transcripts/transcript_map.yaml`) defines available platforms and their command responses.
 
 ### Basic Structure
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -83,7 +83,7 @@ The simplest contribution is adding output for a new command on an existing plat
 vim transcripts/cisco/ios/show_interfaces.txt
 ```
 
-2. Add the command to `transcripts/transcript_map.yaml`:
+2. Add the command to the transcript map file `transcripts/transcript_map.yaml`:
 
 ```yaml
 platforms:
@@ -128,7 +128,7 @@ mkdir -p transcripts/vendor/platform
    - `show_running-config.txt`
    - `show_ip_interface_brief.txt` (or equivalent)
 
-3. Add platform entry to `transcript_map.yaml`:
+3. Add platform entry to the transcript map file (`transcript_map.yaml`):
 
 ```yaml
 platforms:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -68,7 +68,7 @@ ssh -p 10000 admin@localhost
 
 Default password: `admin`
 
-> **Note**: The hostname shown in the prompt (e.g., `cisshgo1000v#`) is determined by the platform's configuration in the transcript map. The default platform is `csr1000v` with hostname `cisshgo1000v`.
+> **Note**: The hostname shown in the prompt (e.g., `cisshgo1000v#`) is determined by the platform's configuration in the transcript map file. The default platform is `csr1000v` with hostname `cisshgo1000v`.
 
 ### Example Session
 
@@ -108,6 +108,6 @@ See [CLI Reference](cli-reference.md) for all available options.
 
 ## Next Steps
 
-- [Configuration](configuration.md) - Learn about transcript maps and inventory files
+- [Configuration](configuration.md) - Learn about transcript map file and inventory files
 - [Transcripts](transcripts.md) - Customize command outputs and add new commands
 - [CLI Reference](cli-reference.md) - Complete CLI flag documentation

--- a/docs/migration-v0.2-to-v1.0.md
+++ b/docs/migration-v0.2-to-v1.0.md
@@ -76,7 +76,7 @@ See the [migration script](#migration-script) to automate this conversion.
 
 ---
 
-### 3. Transcript Paths Resolved Relative to Map File
+### 3. Transcript Paths Resolved Relative to Transcript Map File
 
 In v0.2.0, transcript paths were resolved relative to the **working directory** of the process. In v1.0.0, they are resolved relative to the **directory containing the transcript map file**.
 
@@ -225,7 +225,7 @@ The script handles:
 
 1. **Update CLI flags** in any scripts or tooling (see [CLI flag table](#1-cli-flag-names))
 2. **Migrate transcript map** from list-of-maps to map format (see [migration script](migration-script.md) or [schema change](#2-transcript-map-yaml-schema))
-3. **Verify transcript paths** resolve correctly from the map file's directory
+3. **Verify transcript paths** resolve correctly from the transcript map file's directory
 4. **Optionally adopt** inventory files, scenarios, or new platform transcripts
 
 ---
@@ -239,7 +239,7 @@ The script handles:
 → Your transcript map uses the old list-of-maps format. Run the [migration script](migration-script.md) or update manually.
 
 **`transcript map validation failed: platform "X" command "Y": <path>`**
-→ Transcript paths are now resolved relative to the map file. Check that paths are correct relative to where your `transcript_map.yaml` lives.
+→ Transcript paths are now resolved relative to the transcript map file. Check that paths are correct relative to where your `transcript_map.yaml` lives.
 
 **`platform "csr1000v" not found in transcript map`**
-→ The `--platform` flag defaults to `csr1000v`. If your map uses a different platform name, pass `--platform <name>`.
+→ The `--platform` flag defaults to `csr1000v`. If your transcript map uses a different platform name, pass `--platform <name>`.


### PR DESCRIPTION
Editorial pass to consistently refer to the concept as "transcript map" and the file as "transcript_map.yaml" across all docs. Corrects previous inconsistencies like TranscriptMap or mixed underscores in prose.

closes #110 