### PR TITLE
fix: Add checkout step to coverage-report job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,6 +58,9 @@ jobs:
       actions: read
       pull-requests: write
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      
       - uses: fgrosse/go-coverage-report@v1.1.1
         with:
           coverage-artifact-name: code-coverage


### PR DESCRIPTION
## Problem

The `coverage-report` job in the test workflow was failing on fork PRs with:
```
The current working directory is not inside a git repository
```

This caused PR #140 (and potentially other external contributor PRs) to show failed checks even though tests passed.

## Solution

Added `actions/checkout@v4` step before the `fgrosse/go-coverage-report` action. The action requires the repository to be checked out to generate coverage reports.

## Impact

- Fixes coverage report failures on fork PRs
- No impact on test execution (tests still run and pass)
- Coverage reports will now post correctly to PRs from external contributors

## Testing

This fix will be validated when CI runs on this PR itself.