### PR TITLE
fix: Correct branch references from main to master

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,7 +2,7 @@ name: Docs
 
 on:
   push:
-    branches: [main]
+    branches: [master]
     paths:
       - 'docs/**'
       - 'mkdocs.yml'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,7 +45,7 @@ jobs:
         with:
           config: ./.testcoverage.yml
           profile: coverage.out
-          git-token: ${{ github.ref_name == 'main' && secrets.GITHUB_TOKEN || '' }}
+          git-token: ${{ github.ref_name == 'master' && secrets.GITHUB_TOKEN || '' }}
           git-branch: badges
 
   coverage-report:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,11 +17,11 @@ go test ./...
 
 cisshgo uses [GitHub Flow](https://docs.github.com/en/get-started/using-github/github-flow):
 
-1. Fork the repo and create a branch from `main`
+1. Fork the repo and create a branch from `master`
 2. Make your changes
 3. Ensure tests pass and coverage stays above 90%: `go test -race -coverprofile=coverage.out ./...`
 4. Ensure code is formatted: `gofmt -w ./...`
-5. Open a pull request against `main`
+5. Open a pull request against `master`
 
 Branch naming convention:
 - `feat/short-description` — new features

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Simple, small, fast, concurrent SSH server to emulate network equipment (i.e. Cisco IOS) for testing purposes.
 
 [![CI](https://github.com/tbotnz/cisshgo/actions/workflows/test.yml/badge.svg)](https://github.com/tbotnz/cisshgo/actions/workflows/test.yml)
-[![coverage](https://raw.githubusercontent.com/tbotnz/cisshgo/badges/.badges/main/coverage.svg)](https://github.com/tbotnz/cisshgo/actions/workflows/test.yml)
+[![coverage](https://raw.githubusercontent.com/tbotnz/cisshgo/badges/.badges/master/coverage.svg)](https://github.com/tbotnz/cisshgo/actions/workflows/test.yml)
 [![Go Report Card](https://goreportcard.com/badge/github.com/tbotnz/cisshgo)](https://goreportcard.com/report/github.com/tbotnz/cisshgo)
 [![Go Reference](https://pkg.go.dev/badge/github.com/tbotnz/cisshgo.svg)](https://pkg.go.dev/github.com/tbotnz/cisshgo)
 [![Release](https://img.shields.io/github/v/release/tbotnz/cisshgo)](https://github.com/tbotnz/cisshgo/releases)

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -17,11 +17,11 @@ go test ./...
 
 cisshgo uses [GitHub Flow](https://docs.github.com/en/get-started/using-github/github-flow):
 
-1. Fork the repo and create a branch from `main`
+1. Fork the repo and create a branch from `master`
 2. Make your changes
 3. Ensure tests pass and coverage stays above 90%
 4. Ensure code is formatted with `gofmt`
-5. Open a pull request against `main`
+5. Open a pull request against `master`
 
 ### Branch Naming
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -43,12 +43,12 @@ Cisco IOS XE Software, Version 16.04.01
 ## Project Status
 
 [![CI](https://github.com/tbotnz/cisshgo/actions/workflows/test.yml/badge.svg)](https://github.com/tbotnz/cisshgo/actions/workflows/test.yml)
-[![coverage](https://raw.githubusercontent.com/tbotnz/cisshgo/badges/.badges/main/coverage.svg)](https://github.com/tbotnz/cisshgo/actions/workflows/test.yml)
+[![coverage](https://raw.githubusercontent.com/tbotnz/cisshgo/badges/.badges/master/coverage.svg)](https://github.com/tbotnz/cisshgo/actions/workflows/test.yml)
 [![Go Report Card](https://goreportcard.com/badge/github.com/tbotnz/cisshgo)](https://goreportcard.com/report/github.com/tbotnz/cisshgo)
 
 ## License
 
-MIT License - see [LICENSE](https://github.com/tbotnz/cisshgo/blob/main/LICENSE) file for details.
+MIT License - see [LICENSE](https://github.com/tbotnz/cisshgo/blob/master/LICENSE) file for details.
 
 ## Disclaimer
 


### PR DESCRIPTION
## Problem

The default branch is `master`, but several files referenced `main`, causing:
- **Docs deployment** (`.github/workflows/docs.yml`) never triggers — branch filter was `[main]`
- **Coverage badge push** (`.github/workflows/test.yml`) never fires — condition checked `ref_name == 'main'`
- **Contributing docs** directed contributors to branch from/PR against `main`
- **Badge URLs** pointed to `.badges/main/` path (should be `.badges/master/`)

## Changes

| File | Fix |
|------|-----|
| `CONTRIBUTING.md` | Branch instructions: `main` → `master` |
| `docs/contributing.md` | Branch instructions: `main` → `master` |
| `docs/index.md` | Coverage badge URL + LICENSE link |
| `README.md` | Coverage badge URL |
| `.github/workflows/test.yml` | git-token condition |
| `.github/workflows/docs.yml` | Branch trigger |

## Related

Issue #52 tracks the future rename from `master` to `main`. That issue will be reopened with a checklist of what needs updating when the rename happens.