### PR TITLE
chore: update GitHub Actions to Node.js 24 compatible versions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,10 +15,10 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.x'
       

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,39 +14,39 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: '1.26'
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Syft (for SBOM generation)
-        uses: anchore/sbom-action/download-syft@v0.23.0
+        uses: anchore/sbom-action/download-syft@v0.24.0
 
       - name: Install git-cliff
-        uses: kenji-miyake/setup-git-cliff@v2
+        run: curl -sSfL https://raw.githubusercontent.com/orhun/git-cliff/main/install.sh | sh -s -- --install-path /usr/local/bin
 
       - name: Generate release notes
         run: git-cliff --latest --strip header -o RELEASE_NOTES.md
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@v7
         with:
           version: '~> v2'
           args: release --clean --release-notes=RELEASE_NOTES.md

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,10 +16,10 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: '1.26'
 
@@ -35,7 +35,7 @@ jobs:
         run: go test -coverprofile=coverage.out -covermode=atomic ./...
 
       - name: Upload coverage artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: code-coverage
           path: coverage.out
@@ -59,9 +59,9 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       
-      - uses: fgrosse/go-coverage-report@v1.1.1
+      - uses: fgrosse/go-coverage-report@v1.3.0
         with:
           coverage-artifact-name: code-coverage
           coverage-file-name: coverage.out


### PR DESCRIPTION
## Summary

Update all GitHub Actions across the 3 workflow files to Node.js 24 compatible versions ahead of the June 2, 2026 deadline.

Closes #143

## Changes

### `release.yml` (8 actions → 7 bumped + 1 replaced)

| Action | Before | After |
|---|---|---|
| `actions/checkout` | `@v4` | `@v6` |
| `actions/setup-go` | `@v5` | `@v6` |
| `docker/setup-qemu-action` | `@v3` | `@v4` |
| `docker/setup-buildx-action` | `@v3` | `@v4` |
| `docker/login-action` | `@v3` | `@v4` |
| `anchore/sbom-action/download-syft` | `@v0.23.0` | `@v0.24.0` |
| `goreleaser/goreleaser-action` | `@v6` | `@v7` |
| `kenji-miyake/setup-git-cliff` | `@v2` | **Replaced** with `curl` install |

> **Note:** `kenji-miyake/setup-git-cliff` was [archived on April 7, 2025](https://github.com/kenji-miyake/setup-git-cliff) and will never receive a Node 24 update. Replaced with a direct `curl` install of the git-cliff binary from the upstream repo, which avoids any Node runtime dependency.

### `test.yml` (3 bumped, 3 unchanged)

| Action | Before | After |
|---|---|---|
| `actions/checkout` | `@v4` | `@v6` |
| `actions/setup-go` | `@v5` | `@v6` |
| `actions/upload-artifact` | `@v4` | `@v6` |
| `golangci/golangci-lint-action` | `@v9` | no change (already Node 24) |
| `vladopajic/go-test-coverage` | `@v2` | no change (Go binary) |
| `fgrosse/go-coverage-report` | `@v1.1.1` | `@v1.3.0` |

### `docs.yml` (2 bumped)

| Action | Before | After |
|---|---|---|
| `actions/checkout` | `@v4` | `@v6` |
| `actions/setup-python` | `@v5` | `@v6` |

## Testing

- The test workflow will run on this PR branch and validate the updated actions work correctly
- Release workflow changes can only be fully validated on a tag push, but the action versions are all confirmed to exist and be stable releases
- Docs workflow triggers only on master push to `docs/**` paths