### PR TITLE
feat: add Fortinet FortiOS simulation

### DIFF
--- a/cissh.go
+++ b/cissh.go
@@ -101,11 +101,12 @@ func run(ctx context.Context, cli config.CLI) error {
 		wg.Add(1)
 		go func(cfg listenerConfig) {
 			defer wg.Done()
+			platformHandler, scenarioHandler := handlers.ResolvePlatformHandlers(cfg.fd.Platform)
 			var err error
 			if cfg.sequence != nil {
-				err = sshlisteners.ScenarioListener(ctx, cfg.fd, cfg.sequence, cfg.port)
+				err = sshlisteners.ScenarioListener(ctx, cfg.fd, cfg.sequence, cfg.port, scenarioHandler)
 			} else {
-				err = sshlisteners.GenericListener(ctx, cfg.fd, cfg.port, handlers.GenericCiscoHandler)
+				err = sshlisteners.GenericListener(ctx, cfg.fd, cfg.port, platformHandler)
 			}
 			if err != nil {
 				log.Printf("listener on port %d: %v", cfg.port, err)

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,7 +10,7 @@ cisshgo is a lightweight SSH server that emulates network devices like Cisco rou
 
 - **Fast & Lightweight**: Written in Go, minimal resource usage
 - **Concurrent**: Spawn multiple device instances simultaneously
-- **Flexible**: Support for multiple vendors and platforms (Cisco IOS/IOS-XR/NX-OS/ASA, Arista EOS, Juniper JunOS)
+- **Flexible**: Support for multiple vendors and platforms (Cisco IOS/IOS-XR/NX-OS/ASA, Arista EOS, Juniper JunOS, Fortinet FortiOS)
 - **Customizable**: Easy to add new commands and platforms via YAML configuration
 - **Stateful**: Scenario support for commands that change device state
 - **Multi-device**: Inventory system for complex network topologies

--- a/ssh_server/handlers/fortioshandlers.go
+++ b/ssh_server/handlers/fortioshandlers.go
@@ -1,0 +1,128 @@
+package handlers
+
+import (
+	"io"
+	"log"
+	"strings"
+
+	"github.com/gliderlabs/ssh"
+	"golang.org/x/term"
+
+	"github.com/tbotnz/cisshgo/cmdmatch"
+	"github.com/tbotnz/cisshgo/fakedevices"
+	"github.com/tbotnz/cisshgo/transcript"
+)
+
+const fortiRootContext = "#"
+
+// FortiOSHandler handles FortiOS style sessions.
+func FortiOSHandler(fd *fakedevices.FakeDevice) ssh.Handler {
+	return fortiGateSession(fd, nil)
+}
+
+// FortiOSScenarioHandler returns an ssh.Handler that plays back a scenario sequence.
+func FortiOSScenarioHandler(fd *fakedevices.FakeDevice, sequence []transcript.SequenceStep) ssh.Handler {
+	return fortiGateSession(fd, sequence)
+}
+
+func fortiGateSession(fd *fakedevices.FakeDevice, sequence []transcript.SequenceStep) ssh.Handler {
+	return func(s ssh.Session) {
+		if cmd := s.RawCommand(); cmd != "" {
+			match, matchedCommand, multipleMatches := cmdmatch.Match(cmd, fd.SupportedCommands)
+			if match && !multipleMatches {
+				output, err := fakedevices.TranscriptReader(fd.SupportedCommands[matchedCommand], fd)
+				if err == nil {
+					io.WriteString(s, output)
+				}
+			}
+			s.Exit(0)
+			return
+		}
+
+		seqIdx := 0
+		contextStack := []string{fortiRootContext}
+		t := term.NewTerminal(s, devicePrompt(fd, contextStack[len(contextStack)-1]))
+
+		for {
+			userInput, err := t.ReadLine()
+			if err != nil {
+				break
+			}
+			if strings.TrimSpace(userInput) == "" {
+				t.Write([]byte(""))
+				continue
+			}
+
+			sequenceHandled, terminate := handleSequenceStep(t, userInput, fd, sequence, &seqIdx)
+			if terminate {
+				break
+			}
+
+			if fortiHandleStatefulCommand(t, strings.TrimSpace(userInput), fd, &contextStack) {
+				break
+			}
+
+			if sequenceHandled {
+				continue
+			}
+
+			match, matchedCommand, multipleMatches := cmdmatch.Match(userInput, fd.SupportedCommands)
+			if multipleMatches {
+				t.Write([]byte("Command parse error before '" + userInput + "'\n"))
+				continue
+			}
+			if !match {
+				t.Write([]byte("Command fail. Return code -61\n"))
+				continue
+			}
+			output, err := fakedevices.TranscriptReader(fd.SupportedCommands[matchedCommand], fd)
+			if err != nil {
+				log.Println(err)
+				break
+			}
+			t.Write(append([]byte(output), '\n'))
+		}
+	}
+}
+
+func fortiHandleStatefulCommand(t *term.Terminal, userInput string, fd *fakedevices.FakeDevice, contextStack *[]string) bool {
+	fields := strings.Fields(userInput)
+	if len(fields) == 0 {
+		return false
+	}
+
+	switch fields[0] {
+	case "config":
+		if len(fields) < 2 {
+			t.Write([]byte("Command fail. Return code -61\n"))
+			return false
+		}
+		component := fields[len(fields)-1]
+		*contextStack = append(*contextStack, "("+component+") #")
+		t.SetPrompt(devicePrompt(fd, (*contextStack)[len(*contextStack)-1]))
+		return false
+	case "edit":
+		if len(fields) < 2 {
+			t.Write([]byte("Command fail. Return code -61\n"))
+			return false
+		}
+		name := strings.Join(fields[1:], " ")
+		*contextStack = append(*contextStack, "("+name+") #")
+		t.SetPrompt(devicePrompt(fd, (*contextStack)[len(*contextStack)-1]))
+		return false
+	case "next":
+		if len(*contextStack) > 1 {
+			*contextStack = (*contextStack)[:len(*contextStack)-1]
+		}
+		t.SetPrompt(devicePrompt(fd, (*contextStack)[len(*contextStack)-1]))
+		return false
+	case "end":
+		*contextStack = []string{fortiRootContext}
+		t.SetPrompt(devicePrompt(fd, fortiRootContext))
+		return false
+	case "exit":
+		return true
+	}
+
+	return false
+}

--- a/ssh_server/handlers/fortioshandlers_test.go
+++ b/ssh_server/handlers/fortioshandlers_test.go
@@ -1,0 +1,228 @@
+package handlers
+
+import (
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gliderlabs/ssh"
+	"github.com/tbotnz/cisshgo/fakedevices"
+	"github.com/tbotnz/cisshgo/transcript"
+	gossh "golang.org/x/crypto/ssh"
+)
+
+func newFortiTestDevice() *fakedevices.FakeDevice {
+	return &fakedevices.FakeDevice{
+		Vendor:          "fortinet",
+		Platform:        "fortios",
+		Hostname:        "FGT",
+		DefaultHostname: "FGT",
+		Username:        "admin",
+		Password:        "admin",
+		PromptFormat:    "{hostname} {context}",
+		SupportedCommands: fakedevices.SupportedCommands{
+			"get system status":             "Hostname: {{.Hostname}}\nCurrent virtual domain: root\n",
+			"get system interface":          "== [ port1 ]\nname: port1   mode: static\n",
+			"get router info bgp neighbors": "Neighbor        V         AS MsgRcvd MsgSent   TblVer  InQ OutQ Up/Down  State/PfxRcd\n203.0.113.2     4      64513    1542    1479       18    0    0 2d04h12m           12\n",
+			"show firewall policy":          "config firewall policy\n    edit 1\n    next\nend\n",
+		},
+		ContextSearch: map[string]string{
+			"base": "#",
+		},
+		ContextHierarchy: map[string]string{
+			"#": "exit",
+		},
+	}
+}
+
+func startFortiTestServer(t *testing.T, fd *fakedevices.FakeDevice) (string, func()) {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	addr := ln.Addr().String()
+	ln.Close()
+
+	srv := &ssh.Server{
+		Addr:    addr,
+		Handler: FortiOSHandler(fd),
+		PasswordHandler: func(ctx ssh.Context, pass string) bool {
+			return pass == fd.Password
+		},
+	}
+	go func() { _ = srv.ListenAndServe() }()
+
+	for i := 0; i < 20; i++ {
+		conn, dialErr := net.DialTimeout("tcp", addr, 100*time.Millisecond)
+		if dialErr == nil {
+			conn.Close()
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	return addr, func() { srv.Close() }
+}
+
+func TestResolvePlatformHandlers_FortiOS(t *testing.T) {
+	platformHandler, scenarioHandler := ResolvePlatformHandlers("fortios")
+	if platformHandler == nil || scenarioHandler == nil {
+		t.Fatal("expected handlers for fortios")
+	}
+}
+
+func TestResolvePlatformHandlers_DefaultsToCisco(t *testing.T) {
+	platformHandler, scenarioHandler := ResolvePlatformHandlers("csr1000v")
+	if platformHandler == nil || scenarioHandler == nil {
+		t.Fatal("expected default handlers")
+	}
+}
+
+func TestFortiOSPromptAndContextTransitions(t *testing.T) {
+	fd := newFortiTestDevice()
+	addr, cleanup := startFortiTestServer(t, fd)
+	defer cleanup()
+
+	out := interact(t, addr, []string{"config system interface", "edit port1", "next", "end"})
+	for _, expected := range []string{"FGT #", "FGT (interface) #", "FGT (port1) #"} {
+		if !strings.Contains(out, expected) {
+			t.Fatalf("expected %q in output, got:\n%s", expected, out)
+		}
+	}
+}
+
+func TestFortiOSCommandTranscriptMatch(t *testing.T) {
+	fd := newFortiTestDevice()
+	addr, cleanup := startFortiTestServer(t, fd)
+	defer cleanup()
+
+	out := interact(t, addr, []string{"get system status", "get system interface", "get router info bgp neighbors", "show firewall policy"})
+	if !strings.Contains(out, "Current virtual domain: root") {
+		t.Fatalf("expected system status transcript output, got:\n%s", out)
+	}
+	if !strings.Contains(out, "config firewall policy") {
+		t.Fatalf("expected firewall policy transcript output, got:\n%s", out)
+	}
+	if !strings.Contains(out, "== [ port1 ]") {
+		t.Fatalf("expected system interface transcript output, got:\n%s", out)
+	}
+	if !strings.Contains(out, "State/PfxRcd") {
+		t.Fatalf("expected BGP neighbor transcript output, got:\n%s", out)
+	}
+}
+
+func TestFortiOSUnknownCommand(t *testing.T) {
+	fd := newFortiTestDevice()
+	addr, cleanup := startFortiTestServer(t, fd)
+	defer cleanup()
+
+	out := interact(t, addr, []string{"diagnose sniffer packet any"})
+	if !strings.Contains(out, "Command fail. Return code -61") {
+		t.Fatalf("expected FortiOS-like unknown command error, got:\n%s", out)
+	}
+	if !strings.Contains(out, "FGT #") {
+		t.Fatalf("expected prompt after unknown command, got:\n%s", out)
+	}
+}
+
+func TestFortiOSCIStyleSession(t *testing.T) {
+	fd := newFortiTestDevice()
+	addr, cleanup := startFortiTestServer(t, fd)
+	defer cleanup()
+
+	out := interact(t, addr, []string{"get system status", "config system interface", "edit port1", "next", "end", "show firewall policy"})
+	if !strings.Contains(out, "Hostname: FGT") {
+		t.Fatalf("expected rendered hostname, got:\n%s", out)
+	}
+	if !strings.Contains(out, "FGT (port1) #") {
+		t.Fatalf("expected edit context prompt, got:\n%s", out)
+	}
+	if !strings.Contains(out, "config firewall policy") {
+		t.Fatalf("expected final command output, got:\n%s", out)
+	}
+}
+
+func TestFortiOSExecModeKnownAndUnknown(t *testing.T) {
+	fd := newFortiTestDevice()
+	addr, cleanup := startFortiTestServer(t, fd)
+	defer cleanup()
+
+	config := &gossh.ClientConfig{
+		User:            "admin",
+		Auth:            []gossh.AuthMethod{gossh.Password("admin")},
+		HostKeyCallback: gossh.InsecureIgnoreHostKey(),
+		Timeout:         2 * time.Second,
+	}
+	client, err := gossh.Dial("tcp", addr, config)
+	if err != nil {
+		t.Fatalf("ssh dial: %v", err)
+	}
+	defer client.Close()
+
+	session, err := client.NewSession()
+	if err != nil {
+		t.Fatalf("new session: %v", err)
+	}
+	out, err := session.Output("get system status")
+	session.Close()
+	if err != nil {
+		t.Fatalf("exec known command: %v", err)
+	}
+	if !strings.Contains(string(out), "Current virtual domain: root") {
+		t.Fatalf("expected known exec output, got:\n%s", string(out))
+	}
+
+	session2, err := client.NewSession()
+	if err != nil {
+		t.Fatalf("new session: %v", err)
+	}
+	out2, err := session2.Output("get not real")
+	session2.Close()
+	if err != nil {
+		t.Fatalf("exec unknown command should still exit 0: %v", err)
+	}
+	if len(out2) != 0 {
+		t.Fatalf("expected empty output for unknown exec command, got:\n%s", string(out2))
+	}
+}
+
+func TestFortiOSScenarioHandler(t *testing.T) {
+	fd := newFortiTestDevice()
+	sequence := []transcript.SequenceStep{
+		{Command: "show firewall policy", Transcript: "scenario first\n"},
+		{Command: "show firewall policy", Transcript: "scenario second\n"},
+	}
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	addr := ln.Addr().String()
+	ln.Close()
+
+	srv := &ssh.Server{
+		Addr:    addr,
+		Handler: FortiOSScenarioHandler(fd, sequence),
+		PasswordHandler: func(ctx ssh.Context, pass string) bool {
+			return pass == fd.Password
+		},
+	}
+	go func() { _ = srv.ListenAndServe() }()
+	defer srv.Close()
+
+	for i := 0; i < 20; i++ {
+		conn, dialErr := net.DialTimeout("tcp", addr, 100*time.Millisecond)
+		if dialErr == nil {
+			conn.Close()
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	out := interact(t, addr, []string{"show firewall policy", "show firewall policy"})
+	if !strings.Contains(out, "scenario first") || !strings.Contains(out, "scenario second") {
+		t.Fatalf("expected scenario transcripts in output, got:\n%s", out)
+	}
+}

--- a/ssh_server/handlers/handlers.go
+++ b/ssh_server/handlers/handlers.go
@@ -3,6 +3,8 @@
 package handlers
 
 import (
+	"strings"
+
 	"github.com/gliderlabs/ssh"
 
 	"github.com/tbotnz/cisshgo/fakedevices"
@@ -14,3 +16,13 @@ type PlatformHandler func(*fakedevices.FakeDevice) ssh.Handler
 
 // ScenarioHandler defines a handler type that includes a sequence of steps
 type ScenarioHandler func(*fakedevices.FakeDevice, []transcript.SequenceStep) ssh.Handler
+
+// ResolvePlatformHandlers returns platform-appropriate interactive and scenario handlers.
+func ResolvePlatformHandlers(platform string) (PlatformHandler, ScenarioHandler) {
+	switch strings.ToLower(platform) {
+	case "fortios":
+		return FortiOSHandler, FortiOSScenarioHandler
+	default:
+		return GenericCiscoHandler, GenericCiscoScenarioHandler
+	}
+}

--- a/ssh_server/sshlisteners/sshlisteners.go
+++ b/ssh_server/sshlisteners/sshlisteners.go
@@ -31,8 +31,9 @@ func ScenarioListener(
 	fd *fakedevices.FakeDevice,
 	sequence []transcript.SequenceStep,
 	port int,
+	myHandler handlers.ScenarioHandler,
 ) error {
-	return listen(ctx, fd, port, handlers.GenericCiscoScenarioHandler(fd.Copy(), sequence))
+	return listen(ctx, fd, port, myHandler(fd.Copy(), sequence))
 }
 
 func listen(ctx context.Context, fd *fakedevices.FakeDevice, port int, handler ssh.Handler) error {

--- a/ssh_server/sshlisteners/sshlisteners_test.go
+++ b/ssh_server/sshlisteners/sshlisteners_test.go
@@ -3,6 +3,7 @@ package sshlisteners
 import (
 	"context"
 	"net"
+	"strings"
 	"testing"
 	"time"
 
@@ -10,6 +11,7 @@ import (
 
 	"github.com/tbotnz/cisshgo/fakedevices"
 	"github.com/tbotnz/cisshgo/ssh_server/handlers"
+	"github.com/tbotnz/cisshgo/transcript"
 )
 
 func TestGenericListener(t *testing.T) {
@@ -94,16 +96,28 @@ func TestGenericListener_PortInUse(t *testing.T) {
 		ContextHierarchy:  map[string]string{">": "exit"},
 	}
 
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	ln, err := net.Listen("tcp", ":0")
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer ln.Close()
 	port := ln.Addr().(*net.TCPAddr).Port
 
-	err = GenericListener(context.Background(), fd, port, handlers.GenericCiscoHandler)
-	if err == nil {
-		t.Error("expected error when port is already in use")
+	ctx, cancel := context.WithTimeout(context.Background(), 250*time.Millisecond)
+	defer cancel()
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- GenericListener(ctx, fd, port, handlers.GenericCiscoHandler)
+	}()
+
+	select {
+	case err = <-errCh:
+		if err == nil {
+			t.Error("expected error when port is already in use")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("GenericListener did not return while port was in use")
 	}
 }
 
@@ -158,5 +172,92 @@ func TestGenericListener_UsernameEnforcement(t *testing.T) {
 	_, err = gossh.Dial("tcp", addr, cfg)
 	if err == nil {
 		t.Error("expected auth failure with wrong username")
+	}
+}
+
+func TestScenarioListener(t *testing.T) {
+	fd := &fakedevices.FakeDevice{
+		Vendor:          "fortinet",
+		Platform:        "fortios",
+		Hostname:        "FGT",
+		DefaultHostname: "FGT",
+		Username:        "admin",
+		Password:        "admin",
+		PromptFormat:    "{hostname} {context}",
+		SupportedCommands: fakedevices.SupportedCommands{
+			"show firewall policy": "fallback\n",
+		},
+		ContextSearch:    map[string]string{"base": "#"},
+		ContextHierarchy: map[string]string{"#": "exit"},
+	}
+	sequence := []transcript.SequenceStep{
+		{Command: "show firewall policy", Transcript: "from sequence\n"},
+	}
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	port := ln.Addr().(*net.TCPAddr).Port
+	addr := ln.Addr().String()
+	ln.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() {
+		_ = ScenarioListener(ctx, fd, sequence, port, handlers.FortiOSScenarioHandler)
+	}()
+
+	for i := 0; i < 20; i++ {
+		conn, dialErr := net.DialTimeout("tcp", addr, 100*time.Millisecond)
+		if dialErr == nil {
+			conn.Close()
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	config := &gossh.ClientConfig{
+		User:            "admin",
+		Auth:            []gossh.AuthMethod{gossh.Password("admin")},
+		HostKeyCallback: gossh.InsecureIgnoreHostKey(),
+		Timeout:         2 * time.Second,
+	}
+	client, err := gossh.Dial("tcp", addr, config)
+	if err != nil {
+		t.Fatalf("ssh dial: %v", err)
+	}
+	defer client.Close()
+
+	session, err := client.NewSession()
+	if err != nil {
+		t.Fatalf("new session: %v", err)
+	}
+	defer session.Close()
+
+	if err := session.RequestPty("xterm", 80, 200, gossh.TerminalModes{}); err != nil {
+		t.Fatalf("request pty: %v", err)
+	}
+	stdin, err := session.StdinPipe()
+	if err != nil {
+		t.Fatalf("stdin: %v", err)
+	}
+	stdout, err := session.StdoutPipe()
+	if err != nil {
+		t.Fatalf("stdout: %v", err)
+	}
+	if err := session.Shell(); err != nil {
+		t.Fatalf("shell: %v", err)
+	}
+
+	time.Sleep(150 * time.Millisecond)
+	_, _ = stdin.Write([]byte("show firewall policy\nexit\n"))
+	time.Sleep(150 * time.Millisecond)
+
+	buf := make([]byte, 4096)
+	n, _ := stdout.Read(buf)
+	out := string(buf[:n])
+	if !strings.Contains(out, "from sequence") {
+		t.Fatalf("expected scenario output, got:\n%s", out)
 	}
 }

--- a/transcripts/fortinet/fortios/get_router_info_bgp_neighbors.txt
+++ b/transcripts/fortinet/fortios/get_router_info_bgp_neighbors.txt
@@ -1,0 +1,7 @@
+VRF 0 BGP router identifier 10.0.0.2, local AS number 64512
+BGP table version is 18
+1 BGP AS-PATH entries
+1 BGP community entries
+
+Neighbor        V         AS MsgRcvd MsgSent   TblVer  InQ OutQ Up/Down  State/PfxRcd
+203.0.113.2     4      64513    1542    1479       18    0    0 2d04h12m           12

--- a/transcripts/fortinet/fortios/get_router_info_routing-table_all.txt
+++ b/transcripts/fortinet/fortios/get_router_info_routing-table_all.txt
@@ -1,0 +1,3 @@
+Codes: K - kernel, C - connected, S - static, R - RIP, O - OSPF
+C       10.0.0.0/24 is directly connected, port1
+S*      0.0.0.0/0 [10/0] via 10.0.0.1, port1

--- a/transcripts/fortinet/fortios/get_system_interface.txt
+++ b/transcripts/fortinet/fortios/get_system_interface.txt
@@ -1,0 +1,2 @@
+== [ port1 ]
+name: port1   mode: dhcp    ip: 0.0.0.0 0.0.0.0   status: up    netbios-forward: disable    type: physical   ring-rx: 0   ring-tx: 0   netflow-sampler: disable    sflow-sampler: disable    src-check: enable    explicit-web-proxy: disable    explicit-ftp-proxy: disable    proxy-captive-portal: disable    wccp: disable    drop-overlapped-fragment: disable    drop-fragment: disable    mtu-override: disable

--- a/transcripts/fortinet/fortios/get_system_performance_status.txt
+++ b/transcripts/fortinet/fortios/get_system_performance_status.txt
@@ -1,0 +1,5 @@
+CPU states: 5% user 3% system 0% nice 92% idle
+Memory: 2048 MB total, 742 MB used (36%), 1306 MB free (64%)
+Average network usage: 12 kbps in 9 kbps out
+Average sessions: 124 sessions
+Uptime: 4 days, 6 hours, 21 minutes

--- a/transcripts/fortinet/fortios/get_system_status.txt
+++ b/transcripts/fortinet/fortios/get_system_status.txt
@@ -1,0 +1,8 @@
+Version: FortiGate-VM64 v7.2.6,build1575,240201 (GA)
+Virus-DB: 1.00000(2001-01-01 00:00)
+Extended DB: 1.00000(2001-01-01 00:00)
+IPS-DB: 1.00000(2001-01-01 00:00)
+Serial-Number: FGVM00UNITSANITIZED
+Hostname: {{.Hostname}}
+Current virtual domain: root
+System time: Tue Apr 28 12:00:00 2026

--- a/transcripts/fortinet/fortios/show_firewall_address.txt
+++ b/transcripts/fortinet/fortios/show_firewall_address.txt
@@ -1,0 +1,8 @@
+config firewall address
+    edit "srv-web"
+        set subnet 10.0.10.10 255.255.255.255
+    next
+    edit "net-users"
+        set subnet 10.0.20.0 255.255.255.0
+    next
+end

--- a/transcripts/fortinet/fortios/show_firewall_addrgrp.txt
+++ b/transcripts/fortinet/fortios/show_firewall_addrgrp.txt
@@ -1,0 +1,5 @@
+config firewall addrgrp
+    edit "grp-dmz"
+        set member "srv-web"
+    next
+end

--- a/transcripts/fortinet/fortios/show_firewall_policy.txt
+++ b/transcripts/fortinet/fortios/show_firewall_policy.txt
@@ -1,0 +1,12 @@
+config firewall policy
+    edit 1
+        set name "allow-users-to-web"
+        set srcintf "port1"
+        set dstintf "port2"
+        set srcaddr "net-users"
+        set dstaddr "srv-web"
+        set action accept
+        set schedule "always"
+        set service "HTTP" "HTTPS"
+    next
+end

--- a/transcripts/fortinet/fortios/show_full-configuration.txt
+++ b/transcripts/fortinet/fortios/show_full-configuration.txt
@@ -1,0 +1,15 @@
+config system global
+    set hostname "{{.Hostname}}"
+    set timezone 04
+end
+config system interface
+    edit "port1"
+        set vdom "root"
+        set ip 10.0.0.2 255.255.255.0
+    next
+end
+config firewall address
+    edit "srv-web"
+        set subnet 10.0.10.10 255.255.255.255
+    next
+end

--- a/transcripts/fortinet/fortios/show_system_interface.txt
+++ b/transcripts/fortinet/fortios/show_system_interface.txt
@@ -1,0 +1,14 @@
+config system interface
+    edit "port1"
+        set vdom "root"
+        set ip 10.0.0.2 255.255.255.0
+        set allowaccess ping https ssh
+        set role lan
+    next
+    edit "port2"
+        set vdom "root"
+        set mode dhcp
+        set allowaccess ping
+        set role wan
+    next
+end

--- a/transcripts/fortinet/fortios/show_vpn_ipsec_phase1-interface.txt
+++ b/transcripts/fortinet/fortios/show_vpn_ipsec_phase1-interface.txt
@@ -1,0 +1,10 @@
+config vpn ipsec phase1-interface
+    edit "vpn-branch1"
+        set interface "port2"
+        set peertype any
+        set net-device disable
+        set proposal aes256-sha256
+        set remote-gw 198.51.100.10
+        set psksecret ENC SANITIZEDKEY
+    next
+end

--- a/transcripts/fortinet/fortios/show_vpn_ipsec_phase2-interface.txt
+++ b/transcripts/fortinet/fortios/show_vpn_ipsec_phase2-interface.txt
@@ -1,0 +1,8 @@
+config vpn ipsec phase2-interface
+    edit "vpn-branch1-p2"
+        set phase1name "vpn-branch1"
+        set proposal aes256-sha256
+        set src-subnet 10.0.20.0 255.255.255.0
+        set dst-subnet 10.1.20.0 255.255.255.0
+    next
+end

--- a/transcripts/transcript_map.yaml
+++ b/transcripts/transcript_map.yaml
@@ -138,6 +138,29 @@ platforms:
       "base": ">"
     context_prefix_lines:
       "#": "[edit]"
+  fortios:
+    vendor: "fortinet"
+    hostname: "FGT"
+    username: "admin"
+    password: "admin"
+    prompt_format: "{hostname} {context}"
+    command_transcripts:
+      "get system status": "fortinet/fortios/get_system_status.txt"
+      "get system performance status": "fortinet/fortios/get_system_performance_status.txt"
+      "get router info routing-table all": "fortinet/fortios/get_router_info_routing-table_all.txt"
+      "get router info bgp neighbors": "fortinet/fortios/get_router_info_bgp_neighbors.txt"
+      "get system interface": "fortinet/fortios/get_system_interface.txt"
+      "show system interface": "fortinet/fortios/show_system_interface.txt"
+      "show firewall address": "fortinet/fortios/show_firewall_address.txt"
+      "show firewall addrgrp": "fortinet/fortios/show_firewall_addrgrp.txt"
+      "show firewall policy": "fortinet/fortios/show_firewall_policy.txt"
+      "show vpn ipsec phase1-interface": "fortinet/fortios/show_vpn_ipsec_phase1-interface.txt"
+      "show vpn ipsec phase2-interface": "fortinet/fortios/show_vpn_ipsec_phase2-interface.txt"
+      "show full-configuration": "fortinet/fortios/show_full-configuration.txt"
+    context_hierarchy:
+      "#": "exit"
+    context_search:
+      "base": "#"
 
 scenarios:
   csr1000v-add-interface:


### PR DESCRIPTION
This PR has been assisted by ChatGPT Codex 5.3. I don't know the policy for AI code in this project, but if not accepted, I totally understand.

This adds a new handler for FortiOS and some sample transcripts for same. 

It also alters sshlisteners_test.go slightly to make the test run reliably on MacOS